### PR TITLE
Only assign a public IP address to dmgr VM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
     <groupId>com.ibm.websphere.azure</groupId>
     <artifactId>azure.websphere-traditional.cluster</artifactId>
-    <version>1.3.3</version>
+    <version>1.3.4</version>
     
     <parent>
         <groupId>com.microsoft.azure.iaas</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
     <groupId>com.ibm.websphere.azure</groupId>
     <artifactId>azure.websphere-traditional.cluster</artifactId>
-    <version>1.3.2</version>
+    <version>1.3.3</version>
     
     <parent>
         <groupId>com.microsoft.azure.iaas</groupId>

--- a/src/main/arm/createUiDefinition.json
+++ b/src/main/arm/createUiDefinition.json
@@ -199,9 +199,7 @@
                             "sshPublicKey": "SSH key for admin account of VMs."
                         },
                         "constraints": {
-                            "required": true,
-                            "customPasswordRegex": "^((?=.*[0-9])(?=.*[a-z])(?=.*[A-Z])|(?=.*[0-9])(?=.*[a-z])(?=.*[!@#$%^&*])|(?=.*[0-9])(?=.*[A-Z])(?=.*[!@#$%^&*])|(?=.*[a-z])(?=.*[A-Z])(?=.*[!@#$%^&*])).{12,72}$",
-                            "customValidationMessage": "Password must be at least 12 characters long and have 3 out of the following: one number, one lower case, one upper case, or one special character."
+                            "required": true
                         },
                         "options": {
                             "hideConfirmation": false,

--- a/src/main/arm/mainTemplate.json
+++ b/src/main/arm/mainTemplate.json
@@ -135,6 +135,7 @@
         "name_storageAccount": "[concat('storage',take(replace(parameters('guidValue'),'-',''),6))]",
         "name_virtualNetwork": "[concat(variables('const_dnsLabelPrefix'), '-vnet')]",
         "ref_networkSecurityGroup": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('name_networkSecurityGroup'))]",
+        "ref_publicIPAddress": "[resourceId('Microsoft.Network/publicIPAddresses', variables('name_publicIPAddress'))]",
         "ref_storage": "[resourceId('Microsoft.Storage/storageAccounts', variables('name_storageAccount'))]",
         "ref_subnet": "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('name_virtualNetwork'), variables('const_subnetName'))]",
         "ref_virtualNetwork": "[resourceId('Microsoft.Network/virtualNetworks', variables('name_virtualNetwork'))]"
@@ -230,30 +231,22 @@
         {
             "type": "Microsoft.Network/publicIPAddresses",
             "apiVersion": "${azure.apiVersion}",
-            "name": "[concat(if(equals(copyIndex(), 0), variables('name_dmgrVM'), concat(variables('const_managedVMPrefix'), copyIndex())), '-ip')]",
+            "name": "[variables('name_publicIPAddress')]",
             "location": "[parameters('location')]",
-            "copy": {
-                "name": "publicIPLoop",
-                "count": "[parameters('numberOfNodes')]"
-            },
             "properties": {
                 "publicIPAllocationMethod": "Dynamic",
                 "dnsSettings": {
-                    "domainNameLabel": "[concat(toLower(variables('const_dnsLabelPrefix')), if(equals(copyIndex(), 0), '', concat('-mn', copyIndex())))]"
+                    "domainNameLabel": "[concat(toLower(variables('const_dnsLabelPrefix')))]"
                 }
             }
         },
         {
             "type": "Microsoft.Network/networkInterfaces",
             "apiVersion": "${azure.apiVersion}",
-            "name": "[concat(if(equals(copyIndex(), 0), variables('name_dmgrVM'), concat(variables('const_managedVMPrefix'), copyIndex())), '-if')]",
+            "name": "[concat(variables('name_dmgrVM'), '-if')]",
             "location": "[parameters('location')]",
-            "copy": {
-                "name": "nicLoop",
-                "count": "[parameters('numberOfNodes')]"
-            },
             "dependsOn": [
-                "publicIPLoop",
+                "[variables('ref_publicIPAddress')]",
                 "[variables('ref_subnet')]"
             ],
             "properties": {
@@ -263,8 +256,34 @@
                         "properties": {
                             "privateIPAllocationMethod": "Dynamic",
                             "publicIPAddress": {
-                                "id": "[resourceId('Microsoft.Network/publicIPAddresses', concat(if(equals(copyIndex(), 0), variables('name_dmgrVM'), concat(variables('const_managedVMPrefix'), copyIndex())), '-ip'))]"
+                                "id": "[variables('ref_publicIPAddress')]"
                             },
+                            "subnet": {
+                                "id": "[variables('ref_subnet')]"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Microsoft.Network/networkInterfaces",
+            "apiVersion": "${azure.apiVersion}",
+            "name": "[concat(variables('const_managedVMPrefix'), copyIndex(1), '-if')]",
+            "location": "[parameters('location')]",
+            "copy": {
+                "name": "nicLoop",
+                "count": "[sub(parameters('numberOfNodes'), 1)]"
+            },
+            "dependsOn": [
+                "[variables('ref_subnet')]"
+            ],
+            "properties": {
+                "ipConfigurations": [
+                    {
+                        "name": "ipconfig1",
+                        "properties": {
+                            "privateIPAllocationMethod": "Dynamic",
                             "subnet": {
                                 "id": "[variables('ref_subnet')]"
                             }
@@ -283,6 +302,7 @@
                 "count": "[parameters('numberOfNodes')]"
             },
             "dependsOn": [
+                "[resourceId('Microsoft.Network/networkInterfaces', concat(variables('name_dmgrVM'), '-if'))]",
                 "nicLoop"
             ],
             "properties": {


### PR DESCRIPTION
## Description
This PR is to resolve the following issues:
* Issue #10

## Change summary
* Only assign a public IP address to nic of dmgr VM
* Assign private IP addresses to nics of managed nodes
* Remove unnecessary custom regex and validation message for password in `CredentialsCombo` element: it's not related to the PR topic, but small enough to be contained.

## Test cases
The following cases have already been verified before sending out the PR:
* Successfully deployed a tWAS cluster with one dmgr node and one managed node;
* Dmgr node is assigned with a public IP address;
* Managed node is assigned with a private IP address only; 
* User can `ssh` to the managed node VM with the following steps:
   * Open port 22 in the network security group;
   * `ssh` to the dmgr node VM
   * In dmgr node VM: `ssh` to the managed node VM using its hostname

Signed-off-by: Jianguo Ma <jiangma@microsoft.com>