### PR TITLE
Rename wasadmin to wsadmin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
     <groupId>com.ibm.websphere.azure</groupId>
     <artifactId>azure.websphere-traditional.cluster</artifactId>
-    <version>1.3.5</version>
+    <version>1.3.6</version>
     
     <parent>
         <groupId>com.microsoft.azure.iaas</groupId>

--- a/src/main/arm/createUiDefinition.json
+++ b/src/main/arm/createUiDefinition.json
@@ -205,7 +205,7 @@
                         "name": "wasUsername",
                         "type": "Microsoft.Common.TextBox",
                         "label": "WebSphere administrator",
-                        "defaultValue": "wasadmin",
+                        "defaultValue": "wsadmin",
                         "toolTip": "Use only allowed characters.",
                         "constraints": {
                             "required": true,


### PR DESCRIPTION
## Description
This PR is to resolve the following issues:
* Issue #15

## Change summary
* Rename `wasadmin` to `wsadmin`

## Test cases
No testing needed as the change is simple enough.

Signed-off-by: Jianguo Ma <jiangma@microsoft.com>