### PR TITLE
Open missing ports for dynamic cluster

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
     <groupId>com.ibm.websphere.azure</groupId>
     <artifactId>azure.websphere-traditional.cluster</artifactId>
-    <version>1.3.7</version>
+    <version>1.3.8</version>
     
     <parent>
         <groupId>com.microsoft.azure.iaas</groupId>

--- a/src/main/scripts/install.sh
+++ b/src/main/scripts/install.sh
@@ -29,7 +29,7 @@ create_dmgr_profile() {
     firewall-cmd --zone=public --add-port=8879/tcp --permanent
     firewall-cmd --zone=public --add-port=5555/tcp --permanent
     firewall-cmd --zone=public --add-port=7060/tcp --permanent
-    firewall-cmd --zone=public --add-port=11005/tcp --permanent
+    firewall-cmd --zone=public --add-port=11005/udp --permanent
     firewall-cmd --zone=public --add-port=11006/tcp --permanent
     firewall-cmd --zone=public --add-port=9420/tcp --permanent
     
@@ -146,7 +146,7 @@ create_custom_profile() {
     firewall-cmd --zone=public --add-port=5060/tcp --permanent
     firewall-cmd --zone=public --add-port=5061/tcp --permanent
     firewall-cmd --zone=public --add-port=8880/tcp --permanent
-    firewall-cmd --zone=public --add-port=11003/tcp --permanent
+    firewall-cmd --zone=public --add-port=11003/udp --permanent
     firewall-cmd --zone=public --add-port=11004/tcp --permanent
 
     # Open ports for node agent server
@@ -164,7 +164,7 @@ create_custom_profile() {
     firewall-cmd --zone=public --add-port=8878/tcp --permanent
     firewall-cmd --zone=public --add-port=7061/tcp --permanent
     firewall-cmd --zone=public --add-port=7062/tcp --permanent
-    firewall-cmd --zone=public --add-port=11001/tcp --permanent
+    firewall-cmd --zone=public --add-port=11001/udp --permanent
     firewall-cmd --zone=public --add-port=11002/tcp --permanent
 
     # Open ports for cluster member
@@ -174,7 +174,7 @@ create_custom_profile() {
     firewall-cmd --zone=public --add-port=9352/tcp --permanent
     firewall-cmd --zone=public --add-port=9632/tcp --permanent
     firewall-cmd --zone=public --add-port=9401/tcp --permanent
-    firewall-cmd --zone=public --add-port=11005/tcp --permanent
+    firewall-cmd --zone=public --add-port=11005/udp --permanent
     firewall-cmd --zone=public --add-port=11006/tcp --permanent
     firewall-cmd --zone=public --add-port=8879/tcp --permanent
     firewall-cmd --zone=public --add-port=9060/tcp --permanent
@@ -183,7 +183,7 @@ create_custom_profile() {
     # Open ports for dynamic cluster member
     firewall-cmd --zone=public --add-port=9810/tcp --permanent
     firewall-cmd --zone=public --add-port=9101/tcp --permanent
-    firewall-cmd --zone=public --add-port=11007/tcp --permanent
+    firewall-cmd --zone=public --add-port=11007/udp --permanent
     firewall-cmd --zone=public --add-port=11008/tcp --permanent
     firewall-cmd --zone=public --add-port=9061/tcp --permanent
     firewall-cmd --zone=public --add-port=9044/tcp --permanent

--- a/src/main/scripts/install.sh
+++ b/src/main/scripts/install.sh
@@ -180,6 +180,14 @@ create_custom_profile() {
     firewall-cmd --zone=public --add-port=9060/tcp --permanent
     firewall-cmd --zone=public --add-port=9043/tcp --permanent
 
+    # Open ports for dynamic cluster member
+    firewall-cmd --zone=public --add-port=9810/tcp --permanent
+    firewall-cmd --zone=public --add-port=9101/tcp --permanent
+    firewall-cmd --zone=public --add-port=11007/tcp --permanent
+    firewall-cmd --zone=public --add-port=11008/tcp --permanent
+    firewall-cmd --zone=public --add-port=9061/tcp --permanent
+    firewall-cmd --zone=public --add-port=9044/tcp --permanent
+
     firewall-cmd --reload
 
     profileName=$1


### PR DESCRIPTION
## Description
This PR is to resolve the 2nd part of the following issue:
* Issue #17

## Change summary
* Open additional required ports for dynamic cluster member
* Change from `tcp` to `udp` for udp ports

## Test cases
The following cases have already been verified before sending out the PR:
* Successfully deployed a dynamic cluster with 1 dmgr and 2 managed nodes using Azure CLI;
* After deployment, 1 cluster member is automatically started, which functions as expected based on cluster configuration;

Signed-off-by: Jianguo Ma <jiangma@microsoft.com>