### PR TITLE
Address license concerns.

### DIFF
--- a/src/main/arm/createUiDefinition.json
+++ b/src/main/arm/createUiDefinition.json
@@ -40,7 +40,7 @@
                 "type": "Microsoft.Common.InfoBox",
                 "options": {
                     "icon": "Info",
-                    "text": "Accept the IBM License Agreement to proceed with the deployment. <a href='https://www.ibm.com/software/sla/sladb.nsf/searchlis/?searchview&searchorder=4&searchmax=0&query=%225724-H88%22' target='_blank'>Learn more</a>"
+                    "text": "Accept the IBM License Agreements to proceed with the deployment. <a href='https://aka.ms/tWASNDLicenseAzureVMs' target='_blank'>IBM WebSphere Application Server Network Deployment</a> <a href='https://aka.ms/tWASBaseLicenseAzureVMs' target='_blank'>IBM WebSphere Application Server</a>"
                 }
             },
             {
@@ -52,6 +52,15 @@
                     "required": true,
                     "validationMessage": "The deployment will not proceed unless you accept the IBM License Agreement."
                 }
+            },
+            {
+                "name": "About",
+                "type": "Microsoft.Common.InfoBox",
+                "options": {
+                    "icon": "None",
+                    "text": "Template version ${project.version}"
+                },
+                "visible": "[bool('${template.version.visible}')]"
             }
         ],
         "steps": [


### PR DESCRIPTION
Closes https://github.com/WASdev/azure.websphere-traditional.cluster/issues/3 https://github.com/WASdev/azure.websphere-traditional.cluster/issues/24

modified:   src/main/arm/createUiDefinition.json

- Added hidden version box for testing purposes.

- Add license texts.  Rendered readable here:

```
Accept the IBM License Agreements to proceed with the deployment.

<a href='https://aka.ms/tWASNDLicenseAzureVMs' target='_blank'>IBM WebSphere Application Server Network Deployment</a>

<a href='https://aka.ms/tWASBaseLicenseAzureVMs' target='_blank'>IBM WebSphere Application Server</a>
```

These go to:

https://aka.ms/tWASNDLicenseAzureVMs https://www-03.ibm.com/software/sla/sladb.nsf/displaylis/51D05F1A5B1DF6AA8525869D0013833A?OpenDocument
https://aka.ms/tWASBaseLicenseAzureVMs https://www-03.ibm.com/software/sla/sladb.nsf/displaylis/7C40AF1F7A9F5DD88525869D00138CF7?OpenDocument

respectively.

Signed-off-by: Ed Burns <edburns@microsoft.com>