### PR TITLE
Add pipeline to build artifact

### DIFF
--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -1,0 +1,59 @@
+name: Package ARM
+on:
+  workflow_dispatch:
+  # Allows you to run this workflow using GitHub APIs
+  # PERSONAL_ACCESS_TOKEN=<GITHUB_PERSONAL_ACCESS_TOKEN>
+  # REPO_NAME=WASdev/azure.websphere-traditional.cluster
+  # curl --verbose -XPOST -u "WASdev:${PERSONAL_ACCESS_TOKEN}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" https://api.github.com/repos/${REPO_NAME}/actions/workflows/package.yml/dispatches --data '{"ref": "master"}'
+  repository_dispatch:
+env:
+  refArmttk: d97aa57d259e2fc8562e11501b1cf902265129d9
+  refJavaee: 6addd99d8bc3f472e040f11c053a37e1ac370229
+  repoName: "azure.websphere-traditional.cluster"
+
+jobs:
+  package:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout azure-javaee-iaas
+        uses: actions/checkout@v2
+        with:
+          repository: Azure/azure-javaee-iaas
+          path: azure-javaee-iaas
+          ref: ${{ env.refJavaee }}
+      - name: Checkout arm-ttk
+        uses: actions/checkout@v2
+        with:
+          repository: Azure/arm-ttk
+          path: arm-ttk
+          ref: ${{ env.refArmttk }}
+      - name: Checkout ${{ env.repoName }}
+        uses: actions/checkout@v2
+        with:
+          path: ${{ env.repoName }}
+          ref: ${{ github.event.inputs.ref }}
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: Build azure-javaee-iaas
+        run: mvn -DskipTests clean install --file azure-javaee-iaas/pom.xml
+
+      - name: Build and test ${{ env.repoName }}
+        run: |
+          cd ${{ env.repoName }}
+          mvn -Ptemplate-validation-tests clean install
+      - name: Generate artifact file name and path
+        id: artifact_file
+        run: |
+          version=$(awk '/<version>[^<]+<\/version>/{gsub(/<version>|<\/version>/,"",$1);print $1;exit;}' ${{ env.repoName }}/pom.xml)
+          artifactName=${{ env.repoName }}-$version-arm-assembly
+          unzip ${{ env.repoName }}/target/$artifactName.zip -d ${{ env.repoName }}/target/$artifactName
+          echo "##[set-output name=artifactName;]${artifactName}"
+          echo "##[set-output name=artifactPath;]${{ env.repoName }}/target/$artifactName"
+      - name: Archive ${{ env.repoName }} template
+        uses: actions/upload-artifact@v1
+        if: success()
+        with:
+          name: ${{steps.artifact_file.outputs.artifactName}}
+          path: ${{steps.artifact_file.outputs.artifactPath}}


### PR DESCRIPTION
**Add pipeline to automate artifact building for offer publish**

Step-by-step guidance:
* Use following command to trigger the pipeline
```bash
PERSONAL_ACCESS_TOKEN={your personal token}
REPO_NAME=WASdev/azure.websphere-traditional.cluster
curl --verbose -XPOST -u "WASdev:${PERSONAL_ACCESS_TOKEN}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" https://api.github.com/repos/${REPO_NAME}/actions/workflows/package.yaml/dispatches --data '{"ref": "master"}'
```
* Go to Cluster Repo's action page: https://github.com/WASdev/azure.websphere-traditional.cluster/actions
* Select `Package ARM` under 'All workflows', click on the latest run.
* At the bottom of the action run page, click the artifact and download it for offer publish

Verified in forked repo: https://github.com/zhengchang907/azure.websphere-traditional.cluster/actions/runs/999902501

resolve #76 

[Creating a personal access token](https://docs.github.com/en/github/authenticating-to-github/keeping-your-account-and-data-secure/creating-a-personal-access-token)


Signed-off-by: Zheng Chang <zhengchang@microsoft.com>