### PR TITLE
Configure an IBM HTTP Server in the tWAS cluster

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
     <groupId>com.ibm.websphere.azure</groupId>
     <artifactId>azure.websphere-traditional.cluster</artifactId>
-    <version>1.3.14</version>
+    <version>1.3.15</version>
     
     <parent>
         <groupId>com.microsoft.azure.iaas</groupId>
@@ -38,13 +38,21 @@
         <azure.apiVersion2>2019-06-01</azure.apiVersion2>
         <cluster.start>c2efe274-0dc2-50f3-b51f-338a3fe01afb</cluster.start>
         <cluster.end>9c5dbfce-a6b9-5659-96bc-ca0cf429122a</cluster.end>
+        <ihs.start>5526bacf-3c35-57b7-8b22-337d78b4f478</ihs.start>
+        <ihs.end>3720d7ef-c2dc-5ad4-83bc-96e54bd2bd13</ihs.end>
         <!-- This is the "Partner ID" in Partner Center" -->
         <image.publisher>ibm-usa-ny-armonk-hq-6275750-ibmcloud-aiops</image.publisher>
-        <!-- This is the "Offer ID" of the "Azure Virtual Machine" offer type -->
-        <image.offer>2021-04-27-twas-cluster-base-image</image.offer>
-        <!-- This is the "Plan ID" of the plan within the "Azure Virtual Machine" offer -->
-        <image.sku>2021-04-27-twas-cluster-base-image</image.sku>
-        <!-- This is the "Disk version" of the VM image of the plan within the "Azure Virtual Machine" offer -->
-        <image.version>9.0.20210624</image.version>
+        <!-- This is the twas-nd "Offer ID" of the "Azure Virtual Machine" offer type -->
+        <twasnd.image.offer>2021-04-27-twas-cluster-base-image</twasnd.image.offer>
+        <!-- This is the twas-nd "Plan ID" of the plan within the "Azure Virtual Machine" offer -->
+        <twasnd.image.sku>2021-04-27-twas-cluster-base-image</twasnd.image.sku>
+        <!-- This is the twas-nd "Disk version" of the VM image of the plan within the "Azure Virtual Machine" offer -->
+        <twasnd.image.version>9.0.20210630</twasnd.image.version>
+        <!-- This is the ihs "Offer ID" of the "Azure Virtual Machine" offer type -->
+        <ihs.image.offer>2021-06-03-ihs-base-image</ihs.image.offer>
+        <!-- This is the ihs "Plan ID" of the plan within the "Azure Virtual Machine" offer -->
+        <ihs.image.sku>2021-06-03-ihs-base-image</ihs.image.sku>
+        <!-- This is the ihs "Disk version" of the VM image of the plan within the "Azure Virtual Machine" offer -->
+        <ihs.image.version>9.0.20210630</ihs.image.version>
     </properties>
 </project>

--- a/src/main/arm/createUiDefinition.json
+++ b/src/main/arm/createUiDefinition.json
@@ -15,22 +15,22 @@
             {
                 "name": "ibmUserId",
                 "type": "Microsoft.Common.TextBox",
-                "label": "IBMid",
-                "toolTip": "Your IBMid.",
+                "label": "IBM ID",
+                "toolTip": "Your IBM ID.",
                 "constraints": {
                     "required": true,
                     "regex": "^(?!\\-)([a-z0-9A-Z@\\-]{1,128})([^\\-])",
-                    "validationMessage": "The value must be valid IBMid."
+                    "validationMessage": "The value must be valid IBM ID."
                 }
             },
             {
                 "name": "ibmUserPwd",
                 "type": "Microsoft.Common.PasswordBox",
                 "label": {
-                    "password": "Password for IBMid",
+                    "password": "Password for IBM ID",
                     "confirmPassword": "Confirm password"
                 },
-                "toolTip": "Password for your IBMid.",
+                "toolTip": "Password for your IBM ID.",
                 "constraints": {
                     "required": true
                 }

--- a/src/main/arm/createUiDefinition.json
+++ b/src/main/arm/createUiDefinition.json
@@ -9,7 +9,7 @@
                 "type": "Microsoft.Common.InfoBox",
                 "options": {
                     "icon": "Info",
-                    "text": "Provide an entitled IBMid to provision the WebSphere cluster. <a href='https://www.ibm.com/ibmid/myibm/help/us/helpdesk.html' target='_blank'>Learn more</a>"
+                    "text": "This offer is Bring-Your-Own-License. You will be required to enter your registered IBM ID prior to successfully deploying this offer and your IBM ID must have active WebSphere entitlements associated with it. If you find that provisioning fails due to lack of entitlements, please contact the primary or secondary contacts for your IBM Passport Advantage Site who should be able to grant you access or follow steps at <a href='https://www-112.ibm.com/software/howtobuy/passportadvantage/homepage/ecarec' target='_blank'>IBM eCustomer Care</a> for further assistance. This offer also assumes you are properly licensed to run offers in Microsoft Azure."
                 }
             },
             {

--- a/src/main/arm/createUiDefinition.json
+++ b/src/main/arm/createUiDefinition.json
@@ -9,7 +9,7 @@
                 "type": "Microsoft.Common.InfoBox",
                 "options": {
                     "icon": "Info",
-                    "text": "This offer is Bring-Your-Own-License. You will be required to enter your registered IBM ID prior to successfully deploying this offer and your IBM ID must have active WebSphere entitlements associated with it. If you find that provisioning fails due to lack of entitlements, please contact the primary or secondary contacts for your IBM Passport Advantage Site who should be able to grant you access or follow steps at <a href='https://www-112.ibm.com/software/howtobuy/passportadvantage/homepage/ecarec' target='_blank'>IBM eCustomer Care</a> for further assistance. This offer also assumes you are properly licensed to run offers in Microsoft Azure."
+                    "text": "This offer is Bring-Your-Own-License. To deploy this offer, you must enter your registered IBM ID and your IBM ID must have active WebSphere entitlements associated with it. If provisioning fails due to lack of entitlements, ask the primary or secondary contacts for your IBM Passport Advantage site to grant you access or follow steps at <a href='https://www-112.ibm.com/software/howtobuy/passportadvantage/homepage/ecarec' target='_blank'>IBM eCustomer Care</a> for further assistance. This offer also assumes you are properly licensed to run offers in Microsoft Azure."
                 }
             },
             {
@@ -241,7 +241,7 @@
                         "type": "Microsoft.Common.OptionsGroup",
                         "label": "Configure an IBM HTTP Server?",
                         "defaultValue": "Yes",
-                        "toolTip": "Select 'Yes' and provide required info to configure an IBM HTTP Server.",
+                        "toolTip": "Select 'Yes' and provide the required information to configure an IBM HTTP Server. If you select 'No', you will not be able to use this offer to add IBM HTTP Server later to an existing cluster. You either must set up a new cluster or add IBM HTTP Server manually.",
                         "constraints": {
                             "allowedValues": [
                                 {

--- a/src/main/arm/createUiDefinition.json
+++ b/src/main/arm/createUiDefinition.json
@@ -165,18 +165,7 @@
                             "regex": "^[a-z0-9A-Z]{3,24}$",
                             "validationMessage": "The prefix must be between 3 and 24 characters long and contain letters, numbers only."
                         }
-                    }
-                ]
-            },
-            {
-                "name": "Credentials",
-                "label": "Credentials",
-                "subLabel": {
-                    "preValidation": "Provide Credentials to manage WebSphere cluster",
-                    "postValidation": "Done"
-                },
-                "bladeTitle": "Credentials",
-                "elements": [
+                    },
                     {
                         "name": "adminUsername",
                         "type": "Microsoft.Common.TextBox",
@@ -237,6 +226,153 @@
                         }
                     }
                 ]
+            },
+            {
+                "name": "IHSConfig",
+                "label": "IBM HTTP Server Load Balancer",
+                "subLabel": {
+                    "preValidation": "Configure the IBM HTTP Server load balancer that routes client requests to IBM WebSphere cluster.",
+                    "postValidation": "Done"
+                },
+                "bladeTitle": "IHS configuration",
+                "elements": [
+                    {
+                        "name": "configIHS",
+                        "type": "Microsoft.Common.OptionsGroup",
+                        "label": "Configure an IBM HTTP Server?",
+                        "defaultValue": "Yes",
+                        "toolTip": "Select 'Yes' and provide required info to configure an IBM HTTP Server.",
+                        "constraints": {
+                            "allowedValues": [
+                                {
+                                    "label": "Yes",
+                                    "value": "true"
+                                },
+                                {
+                                    "label": "No",
+                                    "value": "false"
+                                }
+                            ],
+                            "required": true
+                        }
+                    },
+                    {
+                        "name": "ihsInfo",
+                        "type": "Microsoft.Common.Section",
+                        "label": "IBM HTTP Server settings",
+                        "elements": [
+                            {
+                                "name": "ihsVmSize",
+                                "type": "Microsoft.Compute.SizeSelector",
+                                "label": "VM size",
+                                "toolTip": "The size of virtual machine to provision.",
+                                "recommendedSizes": [
+                                    "Standard_D2_v3",
+                                    "Standard_A4_v2",
+                                    "Standard_A2_v2",
+                                    "Standard_A1_v2",
+                                    "Standard_B2ms",
+                                    "Standard_B2s",
+                                    "Standard_B1ms"
+                                ],
+                                "constraints": {
+                                    "excludedSizes": [
+                                        "Standard_B1ls",
+                                        "Standard_A0",
+                                        "Basic_A0",
+                                        "Standard_B1s"
+                                    ]
+                                },
+                                "osPlatform": "Linux",
+                                "count": "1"
+                            },
+                            {
+                                "name": "ihsVMPrefix",
+                                "type": "Microsoft.Common.TextBox",
+                                "label": "IBM HTTP Server prefix",
+                                "toolTip": "The string to prepend to the name of the IBM HTTP Server, default is 'ihs'.",
+                                "defaultValue": "ihs",
+                                "constraints": {
+                                    "required": true,
+                                    "regex": "^[a-z0-9A-Z]{3,14}$",
+                                    "validationMessage": "The prefix must be between 3 and 14 characters long and contain letters, numbers only."
+                                }
+                            },
+                            {
+                                "name": "ihsDnsLabelPrefix",
+                                "type": "Microsoft.Common.TextBox",
+                                "label": "DNS label prefix",
+                                "toolTip": "The string to prepend to the DNS label, default is 'ihs'.",
+                                "defaultValue": "ihs",
+                                "constraints": {
+                                    "required": true,
+                                    "regex": "^[a-z0-9A-Z]{3,24}$",
+                                    "validationMessage": "The prefix must be between 3 and 24 characters long and contain letters, numbers only."
+                                }
+                            },
+                            {
+                                "name": "ihsUnixUsername",
+                                "type": "Microsoft.Common.TextBox",
+                                "label": "VM administrator",
+                                "defaultValue": "ihsadmin",
+                                "toolTip": "Use only letters and numbers.",
+                                "constraints": {
+                                    "required": true,
+                                    "regex": "^[a-z0-9A-Z]{1,30}$",
+                                    "validationMessage": "The value must be 1-30 characters long and must only contain letters and numbers."
+                                }
+                            },
+                            {
+                                "name": "ihsUnixPasswordOrKey",
+                                "type": "Microsoft.Compute.CredentialsCombo",
+                                "label": {
+                                    "authenticationType": "Authentication type",
+                                    "password": "Password for VM administrator",
+                                    "confirmPassword": "Confirm password",
+                                    "sshPublicKey": "SSH Public Key for VM administrator"
+                                },
+                                "toolTip": {
+                                    "authenticationType": "Use user and password or SSH Public Key for authentication to the virtual machine."
+                                },
+                                "constraints": {
+                                    "required": true
+                                },
+                                "options": {
+                                    "hideConfirmation": false,
+                                    "hidePassword": false
+                                },
+                                "osPlatform": "Linux"
+                            },
+                            {
+                                "name": "ihsAdminUsername",
+                                "type": "Microsoft.Common.TextBox",
+                                "label": "IBM HTTP Server administrator",
+                                "defaultValue": "ihsdmin",
+                                "toolTip": "Use only allowed characters.",
+                                "constraints": {
+                                    "required": true,
+                                    "regex": "^[a-z0-9A-Z]{1,30}$",
+                                    "validationMessage": "The value must be 1-30 characters long and must only contain letters and numbers."
+                                }
+                            },
+                            {
+                                "name": "ihsAdminPassword",
+                                "type": "Microsoft.Common.PasswordBox",
+                                "label": {
+                                    "password": "Password for IBM HTTP Server administrator",
+                                    "confirmPassword": "Confirm password"
+                                },
+                                "toolTip": "Password for IBM HTTP Server administrator.",
+                                "constraints": {
+                                    "required": true,
+                                    "regex": "^(?=.*[A-Z])(?=.*[a-z])(?=.*\\d)[A-Za-z\\d]{12,}$",
+                                    "validationMessage": "The password must contain at least 12 characters, with at least 1 uppercase letter, 1 lowercase letter and 1 number, and special characters are not allowed."
+                                }
+                            }
+                        ],
+                        "visible": "[bool(steps('IHSConfig').configIHS)]"
+                    }
+                ]
             }
         ],
         "outputs": {
@@ -249,11 +385,20 @@
             "dmgrVMPrefix": "[steps('ClusterConfig').dmgrVMPrefix]",
             "managedVMPrefix": "[steps('ClusterConfig').managedVMPrefix]",
             "dnsLabelPrefix": "[steps('ClusterConfig').dnsLabelPrefix]",
-            "adminUsername": "[steps('Credentials').adminUsername]",
-            "adminPasswordOrKey": "[if(equals(steps('Credentials').adminPasswordOrKey.authenticationType, 'password'), steps('Credentials').adminPasswordOrKey.password, steps('Credentials').adminPasswordOrKey.sshPublicKey)]",
-            "authenticationType": "[steps('Credentials').adminPasswordOrKey.authenticationType]",
-            "wasUsername": "[steps('Credentials').wasUsername]",
-            "wasPassword": "[steps('Credentials').wasPassword]"
+            "adminUsername": "[steps('ClusterConfig').adminUsername]",
+            "adminPasswordOrKey": "[if(equals(steps('ClusterConfig').adminPasswordOrKey.authenticationType, 'password'), steps('ClusterConfig').adminPasswordOrKey.password, steps('ClusterConfig').adminPasswordOrKey.sshPublicKey)]",
+            "authenticationType": "[steps('ClusterConfig').adminPasswordOrKey.authenticationType]",
+            "wasUsername": "[steps('ClusterConfig').wasUsername]",
+            "wasPassword": "[steps('ClusterConfig').wasPassword]",
+            "configureIHS": "[bool(steps('IHSConfig').configIHS)]",
+            "ihsVmSize": "[steps('IHSConfig').ihsInfo.ihsVmSize]",
+            "ihsVMPrefix": "[steps('IHSConfig').ihsInfo.ihsVMPrefix]",
+            "ihsDnsLabelPrefix": "[steps('IHSConfig').ihsInfo.ihsDnsLabelPrefix]",
+            "ihsUnixUsername": "[steps('IHSConfig').ihsInfo.ihsUnixUsername]",
+            "ihsUnixPasswordOrKey": "[if(equals(steps('IHSConfig').ihsInfo.ihsUnixPasswordOrKey.authenticationType, 'password'), steps('IHSConfig').ihsInfo.ihsUnixPasswordOrKey.password, steps('IHSConfig').ihsInfo.ihsUnixPasswordOrKey.sshPublicKey)]",
+            "ihsAuthenticationType": "[steps('IHSConfig').ihsInfo.ihsUnixPasswordOrKey.authenticationType]",
+            "ihsAdminUsername": "[steps('IHSConfig').ihsInfo.ihsAdminUsername]",
+            "ihsAdminPassword": "[steps('IHSConfig').ihsInfo.ihsAdminPassword]"
         }
     }
 }

--- a/src/main/arm/createUiDefinition.json
+++ b/src/main/arm/createUiDefinition.json
@@ -347,7 +347,7 @@
                                 "name": "ihsAdminUsername",
                                 "type": "Microsoft.Common.TextBox",
                                 "label": "IBM HTTP Server administrator",
-                                "defaultValue": "ihsdmin",
+                                "defaultValue": "ihsadmin",
                                 "toolTip": "Use only allowed characters.",
                                 "constraints": {
                                     "required": true,

--- a/src/main/arm/deploy.azcli
+++ b/src/main/arm/deploy.azcli
@@ -130,6 +130,8 @@ numberOfNodes=$( echo $parametersJson | jq '.numberOfNodes.value' | sed 's/"//g'
 parametersJson=$( echo $parametersJson | jq --argjson cnt "$numberOfNodes" '.numberOfNodes.value = $cnt' )
 dynamic=$( echo $parametersJson | jq '.dynamic.value' | sed 's/"//g' )
 parametersJson=$( echo $parametersJson | jq --argjson dynamic "$dynamic" '.dynamic.value = $dynamic' )
+configureIHS=$( echo $parametersJson | jq '.configureIHS.value' | sed 's/"//g' )
+parametersJson=$( echo $parametersJson | jq --argjson configureIHS "$configureIHS" '.configureIHS.value = $configureIHS' )
 parametersJson=$( echo "$parametersJson" | jq -c '.' )
 
 #Start deployment

--- a/src/main/arm/mainTemplate.json
+++ b/src/main/arm/mainTemplate.json
@@ -51,7 +51,7 @@
             "type": "string",
             "metadata": {
                 "description": "The size of virtual machine to provision for each node of the cluster."
-            }            
+            }
         },
         "dmgrVMPrefix": {
             "type": "string",
@@ -105,6 +105,72 @@
                 "description": "Password for WebSphere admin."
             }
         },
+        "configureIHS": {
+            "type": "bool",
+            "metadata": {
+                "description": "Boolean value indicating, if an IBM HTTP Server load balancer will be configured."
+            }
+        },
+        "ihsVmSize": {
+            "type": "string",
+            "defaultValue": "Standard_D2_v3",
+            "metadata": {
+                "description": "The size of virtual machine to provision for each node of the cluster."
+            }
+        },
+        "ihsVMPrefix": {
+            "type": "string",
+            "defaultValue": "ihs",
+            "metadata": {
+                "description": "The string to prepend to the name of the IBM HTTP Server."
+            }
+        },
+        "ihsDnsLabelPrefix": {
+            "type": "string",
+            "defaultValue": "ihs",
+            "metadata": {
+                "description": "The string to prepend to the DNS label of the IBM HTTP Server."
+            }
+        },
+        "ihsUnixUsername": {
+            "type": "string",
+            "defaultValue": "ihsadmin",
+            "metadata": {
+                "description": "Username for the Virtual Machine of IBM HTTP Server."
+            }
+        },
+        "ihsUnixPasswordOrKey": {
+            "type": "securestring",
+            "defaultValue": "",
+            "metadata": {
+                "description": "SSH Key or password for the Virtual Machine of IBM HTTP Server. SSH key is recommended."
+            }
+        },
+        "ihsAuthenticationType": {
+            "type": "string",
+            "defaultValue": "password",
+            "allowedValues": [
+                "sshPublicKey",
+                "password"
+            ],
+            "metadata": {
+                "description": "Type of authentication to use on the Virtual Machine of IBM HTTP Server. SSH key is recommended."
+            }
+        },
+        "ihsAdminUsername": {
+            "type": "string",
+            "defaultValue": "ihsadmin",
+            "metadata": {
+                "description": "Username for IBM HTTP Server admin."
+            }
+        },
+        "ihsAdminPassword": {
+            "type": "securestring",
+            "defaultValue": "",
+            "metadata": {
+                "description": "Password for IBM HTTP Server admin."
+            }
+        },
         "guidValue": {
             "defaultValue": "[newGuid()]",
             "type": "string"
@@ -112,8 +178,11 @@
     },
     "variables": {
         "const_addressPrefix": "10.0.0.0/16",
-        "const_arguments": "[concat(' -m ',parameters('wasUsername'),' -c ',parameters('wasPassword'),' -h ',variables('name_dmgrVM'),' -r ',sub(parameters('numberOfNodes'),1),' -x ',parameters('dynamic'))]",
+        "const_arguments": "[concat(' ',parameters('wasUsername'),' ',parameters('wasPassword'),' ',variables('name_dmgrVM'),' ',sub(parameters('numberOfNodes'),1),' ',parameters('dynamic'),' ',parameters('configureIHS'))]",
         "const_dnsLabelPrefix": "[concat(parameters('dnsLabelPrefix'), take(replace(parameters('guidValue'),'-',''),6))]",
+        "const_ihsArguments1": "[concat(' ',variables('name_dmgrVM'),' ',parameters('ihsUnixUsername'),' ',parameters('ihsAdminUsername'),' ',parameters('ihsAdminPassword'),' ',variables('name_storageAccount'))]",
+        "const_ihsArguments2": "[concat(' ',variables('name_share'),' ',variables('const_mountPointPath'))]",
+        "const_ihsDnsLabelPrefix": "[concat(parameters('ihsDnsLabelPrefix'), take(replace(parameters('guidValue'),'-',''),6))]",
         "const_linuxConfiguration": {
             "disablePasswordAuthentication": true,
             "ssh": {
@@ -126,17 +195,25 @@
             }
         },
         "const_managedVMPrefix": "[concat(parameters('managedVMPrefix'), take(replace(parameters('guidValue'),'-',''),6), 'VM')]",
+        "const_mountPointPath": "[concat('/mnt/', variables('name_share'))]",
         "const_scriptLocation": "[uri(parameters('_artifactsLocation'), 'scripts/')]",
         "const_subnetAddressPrefix": "10.0.1.0/24",
         "const_subnetName": "subnet01",
         "name_dmgrVM": "[concat(parameters('dmgrVMPrefix'), take(replace(parameters('guidValue'),'-',''),6), 'VM')]",
+        "name_ihsPublicIPAddress": "[concat(variables('name_ihsVM'), '-ip')]",
+        "name_ihsVM": "[concat(parameters('ihsVMPrefix'), take(replace(parameters('guidValue'),'-',''),6), 'VM')]",
         "name_networkSecurityGroup": "[concat(variables('const_dnsLabelPrefix'), '-nsg')]",
         "name_publicIPAddress": "[concat(variables('name_dmgrVM'), '-ip')]",
+        "name_share": "wasshare",
         "name_storageAccount": "[concat('storage',take(replace(parameters('guidValue'),'-',''),6))]",
         "name_virtualNetwork": "[concat(variables('const_dnsLabelPrefix'), '-vnet')]",
+        "ref_fileService": "[resourceId('Microsoft.Storage/storageAccounts/fileServices', variables('name_storageAccount'), 'default')]",
+        "ref_fileShare": "[resourceId('Microsoft.Storage/storageAccounts/fileServices/shares', variables('name_storageAccount'), 'default', variables('name_share'))]",
+        "ref_ihsPublicIPAddress": "[resourceId('Microsoft.Network/publicIPAddresses', variables('name_ihsPublicIPAddress'))]",
         "ref_networkSecurityGroup": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('name_networkSecurityGroup'))]",
         "ref_publicIPAddress": "[resourceId('Microsoft.Network/publicIPAddresses', variables('name_publicIPAddress'))]",
         "ref_storage": "[resourceId('Microsoft.Storage/storageAccounts', variables('name_storageAccount'))]",
+        "ref_storageOrFileShare": "[if(parameters('configureIHS'), variables('ref_fileShare'), variables('ref_storage'))]",
         "ref_subnet": "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('name_virtualNetwork'), variables('const_subnetName'))]",
         "ref_virtualNetwork": "[resourceId('Microsoft.Network/virtualNetworks', variables('name_virtualNetwork'))]"
     },
@@ -165,6 +242,33 @@
             },
             "kind": "Storage",
             "properties": {
+                "supportsHttpsTrafficOnly": false
+            }
+        },
+        {
+            "condition": "[parameters('configureIHS')]",
+            "type": "Microsoft.Storage/storageAccounts/fileServices",
+            "apiVersion": "${azure.apiVersion2}",
+            "name": "[concat(variables('name_storageAccount'), '/default')]",
+            "dependsOn": [
+                "[variables('ref_storage')]"
+            ],
+            "sku": {
+                "name": "Standard_LRS",
+                "tier": "Standard"
+            }
+        },
+        {
+            "condition": "[parameters('configureIHS')]",
+            "type": "Microsoft.Storage/storageAccounts/fileServices/shares",
+            "apiVersion": "${azure.apiVersion2}",
+            "name": "[concat(variables('name_storageAccount'), '/default/', variables('name_share'))]",
+            "dependsOn": [
+                "[variables('ref_fileService')]",
+                "[variables('ref_storage')]"
+            ],
+            "properties": {
+                "shareQuota": 1
             }
         },
         {
@@ -188,7 +292,8 @@
                                 "9060",
                                 "9080",
                                 "9043",
-                                "9443"
+                                "9443",
+                                "80"
                             ]
                         }
                     }
@@ -263,7 +368,10 @@
                             }
                         }
                     }
-                ]
+                ],
+                "dnsSettings": {
+                    "internalDnsNameLabel": "[variables('name_dmgrVM')]"
+                }
             }
         },
         {
@@ -289,7 +397,10 @@
                             }
                         }
                     }
-                ]
+                ],
+                "dnsSettings": {
+                    "internalDnsNameLabel": "[concat(variables('const_managedVMPrefix'), copyIndex(1))]"
+                }
             }
         },
         {
@@ -312,9 +423,9 @@
                 "storageProfile": {
                     "imageReference": {
                         "publisher": "${image.publisher}",
-                        "offer": "${image.offer}",
-                        "sku": "${image.sku}",
-                        "version": "${image.version}"
+                        "offer": "${twasnd.image.offer}",
+                        "sku": "${twasnd.image.sku}",
+                        "version": "${twasnd.image.version}"
                     },
                     "osDisk": {
                         "name": "[concat(if(equals(copyIndex(), 0), variables('name_dmgrVM'), concat(variables('const_managedVMPrefix'), copyIndex())), '-disk')]",
@@ -346,9 +457,9 @@
                 }
             },
             "plan": {
-                "name": "${image.sku}",
+                "name": "${twasnd.image.sku}",
                 "publisher": "${image.publisher}",
-                "product": "${image.offer}"
+                "product": "${twasnd.image.offer}"
             }
         },
         {
@@ -361,6 +472,7 @@
                 "count": "[parameters('numberOfNodes')]"
             },
             "dependsOn": [
+                "[variables('ref_storageOrFileShare')]",
                 "virtualMachineLoop"
             ],
             "properties": {
@@ -372,9 +484,14 @@
                     "fileUris": [
                         "[uri(variables('const_scriptLocation'), concat('install.sh', parameters('_artifactsLocationSasToken')))]",
                         "[uri(variables('const_scriptLocation'), concat('create-cluster.py', parameters('_artifactsLocationSasToken')))]",
-                        "[uri(variables('const_scriptLocation'), concat('create-dcluster.py', parameters('_artifactsLocationSasToken')))]"
-                    ],
-                    "commandToExecute": "[concat('sh install.sh -f ', equals(copyIndex(), 0), variables('const_arguments'))]"
+                        "[uri(variables('const_scriptLocation'), concat('create-dcluster.py', parameters('_artifactsLocationSasToken')))]",
+                        "[uri(variables('const_scriptLocation'), concat('configure-ihs-on-dmgr.sh', parameters('_artifactsLocationSasToken')))]",
+                        "[uri(variables('const_scriptLocation'), concat('configure-im.py', parameters('_artifactsLocationSasToken')))]",
+                        "[uri(variables('const_scriptLocation'), concat('pluginutil.sh', parameters('_artifactsLocationSasToken')))]"
+                    ]
+                },
+                "protectedSettings": {
+                    "commandToExecute": "[concat('sh install.sh ', equals(copyIndex(), 0), variables('const_arguments'), if(parameters('configureIHS'), concat(' ', variables('name_storageAccount'), ' ', listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('name_storageAccount')), '${azure.apiVersion2}').keys[0].value, variables('const_ihsArguments2')), ''))]"
                 }
             }
         },
@@ -384,6 +501,162 @@
             "name": "${cluster.end}",
             "dependsOn": [
                 "virtualMachineExtensionLoop"
+            ],
+            "properties": {
+                "mode": "Incremental",
+                "template": {
+                    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                    "contentVersion": "1.0.0.0",
+                    "resources": [
+                    ]
+                }
+            }
+        },
+        {
+            "condition": "[parameters('configureIHS')]",
+            "type": "Microsoft.Resources/deployments",
+            "apiVersion": "${azure.apiVersion}",
+            "name": "${ihs.start}",
+            "properties": {
+                "mode": "Incremental",
+                "template": {
+                    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                    "contentVersion": "1.0.0.0",
+                    "resources": [
+                    ]
+                }
+            }
+        },
+        {
+            "condition": "[parameters('configureIHS')]",
+            "type": "Microsoft.Network/publicIPAddresses",
+            "apiVersion": "${azure.apiVersion}",
+            "name": "[variables('name_ihsPublicIPAddress')]",
+            "location": "[parameters('location')]",
+            "properties": {
+                "publicIPAllocationMethod": "Dynamic",
+                "dnsSettings": {
+                    "domainNameLabel": "[concat(toLower(variables('const_ihsDnsLabelPrefix')))]"
+                }
+            }
+        },
+        {
+            "condition": "[parameters('configureIHS')]",
+            "type": "Microsoft.Network/networkInterfaces",
+            "apiVersion": "${azure.apiVersion}",
+            "name": "[concat(variables('name_ihsVM'), '-if')]",
+            "location": "[parameters('location')]",
+            "dependsOn": [
+                "[variables('ref_ihsPublicIPAddress')]",
+                "[variables('ref_subnet')]"
+            ],
+            "properties": {
+                "ipConfigurations": [
+                    {
+                        "name": "ipconfig1",
+                        "properties": {
+                            "privateIPAllocationMethod": "Dynamic",
+                            "publicIPAddress": {
+                                "id": "[variables('ref_ihsPublicIPAddress')]"
+                            },
+                            "subnet": {
+                                "id": "[variables('ref_subnet')]"
+                            }
+                        }
+                    }
+                ],
+                "dnsSettings": {
+                    "internalDnsNameLabel": "[variables('name_ihsVM')]"
+                }
+            }
+        },
+        {
+            "condition": "[parameters('configureIHS')]",
+            "type": "Microsoft.Compute/virtualMachines",
+            "apiVersion": "${azure.apiVersion}",
+            "name": "[variables('name_ihsVM')]",
+            "location": "[parameters('location')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Network/networkInterfaces', concat(variables('name_ihsVM'), '-if'))]"
+            ],
+            "properties": {
+                "hardwareProfile": {
+                    "vmSize": "[parameters('ihsVmSize')]"
+                },
+                "storageProfile": {
+                    "imageReference": {
+                        "publisher": "${image.publisher}",
+                        "offer": "${ihs.image.offer}",
+                        "sku": "${ihs.image.sku}",
+                        "version": "${ihs.image.version}"
+                    },
+                    "osDisk": {
+                        "name": "[concat(variables('name_ihsVM'), '-disk')]",
+                        "createOption": "FromImage",
+                        "managedDisk": {
+                            "storageAccountType": "Standard_LRS"
+                        }
+                    }
+                },
+                "osProfile": {
+                    "computerName": "[variables('name_ihsVM')]",
+                    "adminUsername": "[parameters('ihsUnixUsername')]",
+                    "adminPassword": "[parameters('ihsUnixPasswordOrKey')]",
+                    "linuxConfiguration": "[if(equals(parameters('ihsAuthenticationType'), 'password'), json('null'), variables('const_linuxConfiguration'))]",
+                    "customData": "[base64(concat(parameters('ibmUserId'), ' ', parameters('ibmUserPwd')))]"
+                },
+                "networkProfile": {
+                    "networkInterfaces": [
+                        {
+                            "id": "[resourceId('Microsoft.Network/networkInterfaces', concat(variables('name_ihsVM'), '-if'))]"
+                        }
+                    ]
+                },
+                "diagnosticsProfile": {
+                    "bootDiagnostics": {
+                        "enabled": true,
+                        "storageUri": "[reference(variables('ref_storage'), '${azure.apiVersion2}').primaryEndpoints.blob]"
+                    }
+                }
+            },
+            "plan": {
+                "name": "${ihs.image.sku}",
+                "publisher": "${image.publisher}",
+                "product": "${ihs.image.offer}"
+            }
+        },
+        {
+            "condition": "[parameters('configureIHS')]",
+            "type": "Microsoft.Compute/virtualMachines/extensions",
+            "apiVersion": "${azure.apiVersion}",
+            "name": "[concat(variables('name_ihsVM'), '/install')]",
+            "location": "[parameters('location')]",
+            "dependsOn": [
+                "[variables('ref_fileShare')]",
+                "[resourceId('Microsoft.Compute/virtualMachines/', variables('name_ihsVM'))]"
+            ],
+            "properties": {
+                "autoUpgradeMinorVersion": true,
+                "publisher": "Microsoft.Azure.Extensions",
+                "type": "CustomScript",
+                "typeHandlerVersion": "2.0",
+                "settings": {
+                    "fileUris": [
+                        "[uri(variables('const_scriptLocation'), concat('configure-ihs.sh', parameters('_artifactsLocationSasToken')))]"
+                    ]
+                },
+                "protectedSettings": {
+                    "commandToExecute": "[concat('sh configure-ihs.sh', variables('const_ihsArguments1'), ' ', listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('name_storageAccount')), '${azure.apiVersion2}').keys[0].value, variables('const_ihsArguments2'))]"
+                }
+            }
+        },
+        {
+            "condition": "[parameters('configureIHS')]",
+            "type": "Microsoft.Resources/deployments",
+            "apiVersion": "${azure.apiVersion}",
+            "name": "${ihs.end}",
+            "dependsOn": [
+                "[resourceId('Microsoft.Compute/virtualMachines/extensions', variables('name_ihsVM'), 'install')]"
             ],
             "properties": {
                 "mode": "Incremental",
@@ -436,6 +709,10 @@
         "adminSecuredConsole": {
             "type": "string",
             "value": "[concat('https://',reference(variables('name_publicIPAddress')).dnsSettings.fqdn,':9043/ibm/console')]"
+        },
+        "ihsConsole": {
+            "type": "string",
+            "value": "[if(parameters('configureIHS'), concat('http://',reference(variables('name_ihsPublicIPAddress')).dnsSettings.fqdn), 'N/A')]"
         }
     }
 }

--- a/src/main/arm/mainTemplate.json
+++ b/src/main/arm/mainTemplate.json
@@ -26,13 +26,13 @@
         "ibmUserId": {
             "type": "string",
             "metadata": {
-                "description": "Username of your IBMid account."
+                "description": "Username of your IBM ID account."
             }
         },
         "ibmUserPwd": {
             "type": "securestring",
             "metadata": {
-                "description": "Password of your IBMid account."
+                "description": "Password of your IBM ID account."
             }
         },
         "dynamic": {

--- a/src/main/arm/parameters.json
+++ b/src/main/arm/parameters.json
@@ -43,6 +43,33 @@
         },
         "wasPassword": {
             "value": "${wasPassword}"
+        },
+        "configureIHS": {
+            "value": "${configureIHS}"
+        },
+        "ihsVmSize": {
+            "value": "${ihsVmSize}"
+        },
+        "ihsVMPrefix": {
+            "value": "${ihsVMPrefix}"
+        },
+        "ihsDnsLabelPrefix":{
+            "value": "${ihsDnsLabelPrefix}"
+        },
+        "ihsUnixUsername": {
+            "value": "${ihsUnixUsername}"
+        },
+        "ihsUnixPasswordOrKey": {
+            "value": "${ihsUnixPasswordOrKey}"
+        },
+        "ihsAuthenticationType": {
+            "value": "${ihsAuthenticationType}"
+        },
+        "ihsAdminUsername": {
+            "value": "${ihsAdminUsername}"
+        },
+        "ihsAdminPassword": {
+            "value": "${ihsAdminPassword}"
         }
     }
 }

--- a/src/main/scripts/configure-ihs-on-dmgr.sh
+++ b/src/main/scripts/configure-ihs-on-dmgr.sh
@@ -46,6 +46,11 @@ if [[ $? != 0 ]]; then
 fi
 
 # Move the IHS confguration script from Azure File Share system to $WAS_ND_INSTALL_DIRECTORY/bin
+while [ ! -f "$mountpointPath/configurewebserver1.sh" ]
+do
+  echo "$mountpointPath/configurewebserver1.sh is not accessible"
+  sleep 5
+done
 mv $mountpointPath/configurewebserver1.sh $WAS_ND_INSTALL_DIRECTORY/bin
 if [[ $? != 0 ]]; then
   echo "Failed to move $mountpointPath/configurewebserver1.sh to $WAS_ND_INSTALL_DIRECTORY/bin"

--- a/src/main/scripts/configure-ihs-on-dmgr.sh
+++ b/src/main/scripts/configure-ihs-on-dmgr.sh
@@ -1,0 +1,71 @@
+#!/bin/sh
+
+#      Copyright (c) Microsoft Corporation.
+# 
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+# 
+#           http://www.apache.org/licenses/LICENSE-2.0
+# 
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+# Check required parameters
+if [ "$7" == "" ]; then 
+  echo "Usage:"
+  echo "  ./configure-ihs-on-dmgr.sh [profile] [wasUser] [wasPassword] [storageAccountName] [storageAccountKey] [fileShareName] [mountpointPath]"
+  exit 1
+fi
+profile=$1
+wasUser=$2
+wasPassword=$3
+storageAccountName=$4
+storageAccountKey=$5
+fileShareName=$6
+mountpointPath=$7
+
+source /datadrive/virtualimage.properties
+
+# Mount Azure File Share system
+mkdir -p $mountpointPath
+mkdir /etc/smbcredentials
+echo "username=$storageAccountName" > /etc/smbcredentials/${storageAccountName}.cred
+echo "password=$storageAccountKey" >> /etc/smbcredentials/${storageAccountName}.cred
+chmod 600 /etc/smbcredentials/${storageAccountName}.cred
+echo "//${storageAccountName}.file.core.windows.net/${fileShareName} $mountpointPath cifs nofail,vers=2.1,credentials=/etc/smbcredentials/${storageAccountName}.cred,dir_mode=0777,file_mode=0777,serverino" >> /etc/fstab
+
+yum install cifs-utils -y
+mount -t cifs //${storageAccountName}.file.core.windows.net/${fileShareName} $mountpointPath -o vers=2.1,credentials=/etc/smbcredentials/${storageAccountName}.cred,dir_mode=0777,file_mode=0777,serverino
+if [[ $? != 0 ]]; then
+  echo "Failed to mount //${storageAccountName}.file.core.windows.net/${fileShareName} $mountpointPath"
+  exit 1
+fi
+
+# Move the IHS confguration script from Azure File Share system to $WAS_ND_INSTALL_DIRECTORY/bin
+mv $mountpointPath/configurewebserver1.sh $WAS_ND_INSTALL_DIRECTORY/bin
+if [[ $? != 0 ]]; then
+  echo "Failed to move $mountpointPath/configurewebserver1.sh to $WAS_ND_INSTALL_DIRECTORY/bin"
+  exit 1
+fi
+
+# Get node name of IHS server
+read -r -a cmds <<<`(tail -n1) <$WAS_ND_INSTALL_DIRECTORY/bin/configurewebserver1.sh`
+nodeName=${cmds[14]}
+
+echo "Configure IHS on the DMgr"
+$WAS_ND_INSTALL_DIRECTORY/bin/configurewebserver1.sh -profileName $profile -user $wasUser -password $wasPassword >/dev/null 2>&1
+rm -rf $WAS_ND_INSTALL_DIRECTORY/bin/configurewebserver1.sh
+
+# Configure intelligent management for IHS
+$WAS_ND_INSTALL_DIRECTORY/bin/wsadmin.sh -f configure-im.py $nodeName webserver1
+
+# Generate, propagate plugin-cfg.xml and restart IHS
+mv pluginutil.sh $WAS_ND_INSTALL_DIRECTORY/bin
+$WAS_ND_INSTALL_DIRECTORY/bin/pluginutil.sh generate webserver1 $nodeName
+$WAS_ND_INSTALL_DIRECTORY/bin/pluginutil.sh propagate webserver1 $nodeName
+$WAS_ND_INSTALL_DIRECTORY/bin/pluginutil.sh propagateKeyring webserver1 $nodeName
+$WAS_ND_INSTALL_DIRECTORY/bin/pluginutil.sh restart webserver1 $nodeName

--- a/src/main/scripts/configure-ihs.sh
+++ b/src/main/scripts/configure-ihs.sh
@@ -1,0 +1,82 @@
+#!/bin/sh
+
+#      Copyright (c) Microsoft Corporation.
+# 
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+# 
+#           http://www.apache.org/licenses/LICENSE-2.0
+# 
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+# parameters needed:
+#   - dmgrHostname, ihsUnixUsername, ihsAdminUsername, ihsAdminPassword, storageAccountName, storageAccountKey, fileShareName, mountpointPath
+if [ "$3" == "" ]; then 
+  echo "Usage:"
+  echo "  ./configure-ihs.sh [dmgrHostname] [ihsUnixUsername] [ihsAdminUsername] [ihsAdminPassword] [storageAccountName] [storageAccountKey] [fileShareName] [mountpointPath]"
+  exit 1
+fi
+dmgrHostname=$1
+ihsUnixUsername=$2
+ihsAdminUsername=$3
+ihsAdminPassword=$4
+storageAccountName=$5
+storageAccountKey=$6
+fileShareName=$7
+mountpointPath=$8
+
+firewall-cmd --zone=public --add-port=80/tcp --permanent
+firewall-cmd --zone=public --add-port=8008/tcp --permanent
+firewall-cmd --reload
+
+source /datadrive/virtualimage.properties
+hostname=`hostname`
+responseFile="pct.response.txt"
+
+echo "configType=remote" > $responseFile
+echo "enableAdminServerSupport=true" >> $responseFile
+echo "enableUserAndPass=true" >> $responseFile
+echo "enableWinService=false" >> $responseFile
+echo "ihsAdminCreateUserAndGroup=true" >> $responseFile
+echo "ihsadminPort=8008" >> $responseFile
+echo "ihsAdminUnixUserID=$ihsUnixUsername" >> $responseFile
+echo "ihsAdminUnixUserGroup=$ihsUnixUsername" >> $responseFile
+echo "ihsAdminUserID=$ihsAdminUsername" >> $responseFile
+echo "ihsAdminPassword=$ihsAdminPassword" >> $responseFile
+echo "mapWebServerToApplications=true" >> $responseFile
+echo "wasMachineHostName=$dmgrHostname" >> $responseFile
+echo "webServerConfigFile1=$IHS_INSTALL_DIRECTORY/conf/httpd.conf" >> $responseFile
+echo "webServerDefinition=webserver1" >> $responseFile
+echo "webServerHostName=$hostname" >> $responseFile
+echo "webServerInstallArch=64" >> $responseFile
+echo "webServerPortNumber=80" >> $responseFile
+echo "webServerSelected=ihs" >> $responseFile
+echo "webServerType=IHS" >> $responseFile
+
+$WCT_INSTALL_DIRECTORY/WCT/wctcmd.sh -tool pct -importDefinitionLocation -defLocPathname $PLUGIN_INSTALL_DIRECTORY -defLocName WS1 -response $responseFile
+$IHS_INSTALL_DIRECTORY/bin/adminctl start
+
+mkdir -p $mountpointPath
+mkdir /etc/smbcredentials
+echo "username=$storageAccountName" > /etc/smbcredentials/${storageAccountName}.cred
+echo "password=$storageAccountKey" >> /etc/smbcredentials/${storageAccountName}.cred
+chmod 600 /etc/smbcredentials/${storageAccountName}.cred
+echo "//${storageAccountName}.file.core.windows.net/${fileShareName} $mountpointPath cifs nofail,vers=2.1,credentials=/etc/smbcredentials/${storageAccountName}.cred,dir_mode=0777,file_mode=0777,serverino" >> /etc/fstab
+
+yum install cifs-utils -y
+mount -t cifs //${storageAccountName}.file.core.windows.net/${fileShareName} $mountpointPath -o vers=2.1,credentials=/etc/smbcredentials/${storageAccountName}.cred,dir_mode=0777,file_mode=0777,serverino
+if [[ $? != 0 ]]; then
+  echo "Failed to mount //${storageAccountName}.file.core.windows.net/${fileShareName} $mountpointPath"
+  exit 1
+fi
+
+mv $PLUGIN_INSTALL_DIRECTORY/bin/configurewebserver1.sh $mountpointPath
+if [[ $? != 0 ]]; then
+  echo "Failed to move $PLUGIN_INSTALL_DIRECTORY/bin/configurewebserver1.sh to $mountpointPath"
+  exit 1
+fi

--- a/src/main/scripts/configure-ihs.sh
+++ b/src/main/scripts/configure-ihs.sh
@@ -61,6 +61,8 @@ echo "webServerType=IHS" >> $responseFile
 
 # Configure IHS using WCT
 $WCT_INSTALL_DIRECTORY/WCT/wctcmd.sh -tool pct -importDefinitionLocation -defLocPathname $PLUGIN_INSTALL_DIRECTORY -defLocName WS1 -response $responseFile
+rm -rf $responseFile
+
 # Start IHS admin server
 $IHS_INSTALL_DIRECTORY/bin/adminctl start
 

--- a/src/main/scripts/configure-ihs.sh
+++ b/src/main/scripts/configure-ihs.sh
@@ -14,9 +14,8 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-# parameters needed:
-#   - dmgrHostname, ihsUnixUsername, ihsAdminUsername, ihsAdminPassword, storageAccountName, storageAccountKey, fileShareName, mountpointPath
-if [ "$3" == "" ]; then 
+# Check required parameters
+if [ "$8" == "" ]; then 
   echo "Usage:"
   echo "  ./configure-ihs.sh [dmgrHostname] [ihsUnixUsername] [ihsAdminUsername] [ihsAdminPassword] [storageAccountName] [storageAccountKey] [fileShareName] [mountpointPath]"
   exit 1
@@ -30,6 +29,7 @@ storageAccountKey=$6
 fileShareName=$7
 mountpointPath=$8
 
+# Open ports
 firewall-cmd --zone=public --add-port=80/tcp --permanent
 firewall-cmd --zone=public --add-port=8008/tcp --permanent
 firewall-cmd --reload
@@ -38,6 +38,7 @@ source /datadrive/virtualimage.properties
 hostname=`hostname`
 responseFile="pct.response.txt"
 
+# Create response file
 echo "configType=remote" > $responseFile
 echo "enableAdminServerSupport=true" >> $responseFile
 echo "enableUserAndPass=true" >> $responseFile
@@ -58,9 +59,12 @@ echo "webServerPortNumber=80" >> $responseFile
 echo "webServerSelected=ihs" >> $responseFile
 echo "webServerType=IHS" >> $responseFile
 
+# Configure IHS using WCT
 $WCT_INSTALL_DIRECTORY/WCT/wctcmd.sh -tool pct -importDefinitionLocation -defLocPathname $PLUGIN_INSTALL_DIRECTORY -defLocName WS1 -response $responseFile
+# Start IHS admin server
 $IHS_INSTALL_DIRECTORY/bin/adminctl start
 
+# Mount Azure File Share system
 mkdir -p $mountpointPath
 mkdir /etc/smbcredentials
 echo "username=$storageAccountName" > /etc/smbcredentials/${storageAccountName}.cred
@@ -75,6 +79,7 @@ if [[ $? != 0 ]]; then
   exit 1
 fi
 
+# Move the IHS confguration script to Azure File Share system
 mv $PLUGIN_INSTALL_DIRECTORY/bin/configurewebserver1.sh $mountpointPath
 if [[ $? != 0 ]]; then
   echo "Failed to move $PLUGIN_INSTALL_DIRECTORY/bin/configurewebserver1.sh to $mountpointPath"

--- a/src/main/scripts/configure-im.py
+++ b/src/main/scripts/configure-im.py
@@ -1,0 +1,48 @@
+#      Copyright (c) Microsoft Corporation.
+# 
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+# 
+#           http://www.apache.org/licenses/LICENSE-2.0
+# 
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+# Usage method
+def usage():
+    print ""
+    print "Usage to configure IM:"
+    print "  wsadmin -lang jython -f configure-im.py nodename webserver" 
+    sys.exit()
+
+# Init the global variables
+ischanged = 0
+
+# Next get the policy set, node and cell
+try:
+    nodename = sys.argv[0]
+    webserver = sys.argv[1]
+except:
+    print 'Missing parms.'
+    usage()
+
+try:
+    attrs = '-node "' + nodename + '" -webserver "' + webserver + '"'
+    AdminTask.enableIntelligentManagement([attrs]) 
+    ischanged = 1
+except:
+    print "Unexpected error:", sys.exc_info()[0], sys.exc_info()[1], sys.exc_info()[2]
+    print "Enable failed"
+
+# Save after the action is done
+if 1 == ischanged:
+    print "Saving configuration ..."
+    AdminConfig.save()
+
+else:
+    AdminConfig.reset()
+    print "Not Saving configuration. No Changes To Save"

--- a/src/main/scripts/install.sh
+++ b/src/main/scripts/install.sh
@@ -246,6 +246,28 @@ while getopts "m:c:f:h:r:x:" opt; do
     esac
 done
 
+# Check required parameters
+if [ "$7" = True ] && [ "${11}" == "" ]; then 
+  echo "Usage:"
+  echo "  ./install.sh [dmgr] [adminUserName] [adminPassword] [dmgrHostName] [members] [dynamic] True [storageAccountName] [storageAccountKey] [fileShareName] [mountpointPath]"
+  exit 1
+elif [ "$7" == "" ]; then 
+  echo "Usage:"
+  echo "  ./install.sh [dmgr] [adminUserName] [adminPassword] [dmgrHostName] [members] [dynamic] False"
+  exit 1
+fi
+dmgr=$1
+adminUserName=$2
+adminPassword=$3
+dmgrHostName=$4
+members=$5
+dynamic=$6
+configureIHS=$7
+storageAccountName=$8
+storageAccountKey=$9
+fileShareName=${10}
+mountpointPath=${11}
+
 # Check whether the user is entitled or not
 while [ ! -f "/var/log/cloud-init-was.log" ]
 do
@@ -282,6 +304,11 @@ if [ "$dmgr" = True ]; then
     create_systemd_service was_dmgr "IBM WebSphere Application Server ND Deployment Manager" Dmgr001 dmgr
     ${WAS_ND_INSTALL_DIRECTORY}/profiles/Dmgr001/bin/startServer.sh dmgr
     create_cluster Dmgr001 Dmgr001Node Dmgr001NodeCell MyCluster $members $dynamic
+
+    # Configure IHS if required
+    if [ "$configureIHS" = True ]; then
+        ./configure-ihs-on-dmgr.sh Dmgr001 "$adminUserName" "$adminPassword" "$storageAccountName" "$storageAccountKey" "$fileShareName" "$mountpointPath"
+    fi
 else
     create_custom_profile Custom $(hostname) $(hostname)Node01 $dmgrHostName 8879 "$adminUserName" "$adminPassword"
     add_admin_credentials_to_soap_client_props Custom "$adminUserName" "$adminPassword"

--- a/src/main/scripts/install.sh
+++ b/src/main/scripts/install.sh
@@ -223,51 +223,6 @@ create_custom_profile() {
     echo $output
 }
 
-while getopts "m:c:f:h:r:x:" opt; do
-    case $opt in
-        m)
-            adminUserName=$OPTARG #User id for admimistrating WebSphere Admin Console
-        ;;
-        c)
-            adminPassword=$OPTARG #Password for administrating WebSphere Admin Console
-        ;;
-        f)
-            dmgr=$OPTARG #Flag indicating whether to install deployment manager
-        ;;
-        h)
-            dmgrHostName=$OPTARG #Host name of deployment manager server
-        ;;
-        r)
-            members=$OPTARG #Number of cluster members
-        ;;
-        x)
-            dynamic=$OPTARG #Flag indicating whether to create a dynamic cluster or not
-        ;;
-    esac
-done
-
-# Check required parameters
-if [ "$7" = True ] && [ "${11}" == "" ]; then 
-  echo "Usage:"
-  echo "  ./install.sh [dmgr] [adminUserName] [adminPassword] [dmgrHostName] [members] [dynamic] True [storageAccountName] [storageAccountKey] [fileShareName] [mountpointPath]"
-  exit 1
-elif [ "$7" == "" ]; then 
-  echo "Usage:"
-  echo "  ./install.sh [dmgr] [adminUserName] [adminPassword] [dmgrHostName] [members] [dynamic] False"
-  exit 1
-fi
-dmgr=$1
-adminUserName=$2
-adminPassword=$3
-dmgrHostName=$4
-members=$5
-dynamic=$6
-configureIHS=$7
-storageAccountName=$8
-storageAccountKey=$9
-fileShareName=${10}
-mountpointPath=${11}
-
 # Check whether the user is entitled or not
 while [ ! -f "/var/log/cloud-init-was.log" ]
 do
@@ -293,6 +248,28 @@ cloud-init clean --logs
 if [ ${result} = Unentitled ]; then
     exit 1
 fi
+
+# Check required parameters
+if [ "$7" = True ] && [ "${11}" == "" ]; then 
+  echo "Usage:"
+  echo "  ./install.sh [dmgr] [adminUserName] [adminPassword] [dmgrHostName] [members] [dynamic] True [storageAccountName] [storageAccountKey] [fileShareName] [mountpointPath]"
+  exit 1
+elif [ "$7" == "" ]; then 
+  echo "Usage:"
+  echo "  ./install.sh [dmgr] [adminUserName] [adminPassword] [dmgrHostName] [members] [dynamic] False"
+  exit 1
+fi
+dmgr=$1
+adminUserName=$2
+adminPassword=$3
+dmgrHostName=$4
+members=$5
+dynamic=$6
+configureIHS=$7
+storageAccountName=$8
+storageAccountKey=$9
+fileShareName=${10}
+mountpointPath=${11}
 
 # Get tWAS installation properties
 source /datadrive/virtualimage.properties

--- a/src/main/scripts/pluginutil.sh
+++ b/src/main/scripts/pluginutil.sh
@@ -1,0 +1,118 @@
+#!/bin/sh
+
+#      Copyright (c) Microsoft Corporation.
+# 
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+# 
+#           http://www.apache.org/licenses/LICENSE-2.0
+# 
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+# Wrapper to invoke the PluginCfgGenerator mbean from a dmgr to generate plugin-cfg.xml, propagate plugin-cfg.xml,
+# propagate plugin-key.kdb, and restart web server
+
+# This script must live in $WAS_ND_INSTALL_DIRECTORY/bin
+
+source /datadrive/virtualimage.properties
+
+binDir=`dirname $0`
+source $binDir/setupCmdLine.sh
+
+if [ $# -lt 1 ]; then
+  echo "$0 list [ ... wsadmin args ]"
+  echo "$0 generate|propagate|propagateKeyring webserver-name webserver-node-name [ ... wsadmin args ]"
+  echo "$0 ping|stop|start|restart webserver-name webserver-node-name [ ... wsadmin args ]"
+  exit 1
+fi
+
+OP=$1
+if [ $OP = "list" ]; then
+(${WAS_ND_INSTALL_DIRECTORY}/bin/wsadmin.sh -lang jython -conntype NONE "$@" | sed -e 's/wsadmin>//')<<ENDHEREDOC1
+print ""
+print AdminTask.listServers('[-serverType WEB_SERVER ]')
+ENDHEREDOC1
+exit
+fi
+
+if [ $# -lt 3 ]; then
+  echo "$0 list [ ... wsadmin args ]"
+  echo "$0 generate|propagate|propagateKeyring webserver-name webserver-node-name [ ... wsadmin args ]"
+  echo "$0 ping|stop|start|restart webserver-name webserver-node-name [ ... wsadmin args ]"
+  exit 1
+fi
+
+WEBSERVER=$2
+NODE=$3
+
+shift 3
+
+# Check that the user didn't need to pass credentials as supplicant args, e.g. no soap.client.props
+if [[ ! $@ == *'-password'* ]];  then
+    echo "Checking wsadmin access"
+    echo "print ''" | ${WAS_ND_INSTALL_DIRECTORY}/bin/wsadmin.sh -lang jython "$@" | grep WASX7246E > /dev/null
+    if [ $? -eq 0 ]; then
+      echo "$0 You must setup soap.client.props or pass -user ... -password ... to this command"
+      exit 1
+    fi
+fi
+
+echo "Requesting mbean op: $OP"
+
+case $OP in 
+   ping|stop|start)
+(${WAS_ND_INSTALL_DIRECTORY}/bin/wsadmin.sh -lang jython "$@" | sed -e 's/wsadmin>//g') <<ENDHEREDOC
+mbean = AdminControl.queryNames("WebSphere:*,process=dmgr,type=WebServer")
+args = '[$WAS_CELL $NODE $WEBSERVER]'
+print AdminControl.invoke(mbean, '$OP', args)
+ENDHEREDOC
+;;
+   restart)
+(${WAS_ND_INSTALL_DIRECTORY}/bin/wsadmin.sh -lang jython "$@" | sed -e 's/wsadmin>//g') <<ENDHEREDOC
+import time
+mbean = AdminControl.queryNames("WebSphere:*,process=dmgr,type=WebServer")
+args = '[$WAS_CELL $NODE $WEBSERVER]'
+status = AdminControl.invoke(mbean, 'ping', args)
+print "$WEBSERVER is %s" % (status)
+if status == "RUNNING":
+    print "Stopping $WEBSERVER"
+    AdminControl.invoke(mbean, 'stop', args)
+    print "Waiting for $WEBSERVER to stop"
+    for i in range(10):
+        if status == "STOPPED":
+            print "$WEBSERVER is stopped"
+            break
+        status = AdminControl.invoke(mbean, 'ping', args)
+        sleep(i)
+    else:
+        print "Timed out stopping $WEBSERVER"
+
+print "Starting $WEBSERVER"
+AdminControl.invoke(mbean, 'start', args)
+for i in range(10):
+    status = AdminControl.invoke(mbean, 'ping', args)
+    if status == "STARTED":
+        print "$WEBSERVER is started"
+        break
+    sleep(i)
+else:
+    print "Timed out starting $WEBSERVER"
+ENDHEREDOC
+;;
+
+   *)
+(${WAS_ND_INSTALL_DIRECTORY}/bin/wsadmin.sh -lang jython "$@" | sed -e 's/wsadmin>//g') <<ENDHEREDOC
+mbean = AdminControl.queryNames("WebSphere:*,process=dmgr,type=PluginCfgGenerator")
+args = '[%s/config %s %s %s %s]' % ('$USER_INSTALL_ROOT', '$WAS_CELL', '$NODE', '$WEBSERVER', "false" if "$OP" == "generate" else "")
+types = '[java.lang.String java.lang.String java.lang.String java.lang.String %s]' % ("java.lang.Boolean" if "$OP" == "generate" else "")
+result = AdminControl.invoke(mbean, '$OP', args, types)
+AdminConfig.save()
+ENDHEREDOC
+;;
+esac
+echo "Done"


### PR DESCRIPTION
## Description
This PR is to resolve the following issues:
* Resolve #37 
* Resolve #40 
* Resolve #84 

## Change summary
* Automation scripts to configure IHS on both ihs & dmgr VMs
* ARM template to deploy Azure resources for IHS 
* UI to configure IHS on Azure Portal 
* Enhance text in `createUiDefinition.json` to aid people getting an entitlement
* Use IBM ID rather than IBMid consistently

## Test cases
The following cases have already been verified before sending out the PR. You can have a try using the [preview link](https://portal.azure.com/#create/microsoft_javaeeonazure_test.20191212-arm-rhel-was-nd-v9-cluster-previewwasndt91-n-cluster) also.
* Successfully deployed a tWAS cluster with an a working IHS if specified by the user on Azure Portal;
  * Successfully installed `DefaultApplication` (shipped with WAS ND installation) which can be visited from the public IP address of IHS;
* Successfully deployed a tWAS cluster without an an IHS if not specified by the user on Azure Portal;

Signed-off-by: Jianguo Ma <jiangma@microsoft.com>