### PR TITLE
Fix issues 35, 39, 85 and part of 56

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # [Related: Base images deployed by this Azure application](https://github.com/WASdev/azure.websphere-traditional.image)
 
-# Deploy RHEL 8.3 VMs on Azure with IBM WebSphere Application Server ND Traditional V9.0.5 cluster pre-installed
+# Deploy RHEL 8.3 VMs on Azure with IBM WebSphere Application Server ND Traditional V9.0.5 cluster and IBM HTTP Server V9.0 pre-installed
 
 ## Prerequisites
 
@@ -20,7 +20,7 @@
 1. Build the project by replacing all placeholder `${<place_holder>}` with valid values
 
    ```bash
-   mvn -Dgit.repo=<repo_user> -Dgit.tag=<repo_tag> -DibmUserId=<ibmUserId> -DibmUserPwd=<ibmUserPwd> -Ddynamic=<true|false> -DnumberOfNodes=<numberOfNodes> -DvmSize=<vmSize> -DdmgrVMPrefix=<dmgrVMPrefix> -DmanagedVMPrefix=<managedVMPrefix> -DdnsLabelPrefix=<dnsLabelPrefix> -DadminUsername=<adminUsername> -DadminPasswordOrKey=<adminPassword|adminSSHPublicKey> -DauthenticationType=<password|sshPublicKey> -DwasUsername=<wasUsername> -DwasPassword=<wasPassword> -Dtest.args="-Test All" -Ptemplate-validation-tests clean install
+   mvn -Dgit.repo=<repo_user> -Dgit.tag=<repo_tag> -DibmUserId=<ibmUserId> -DibmUserPwd=<ibmUserPwd> -Ddynamic=<true|false> -DnumberOfNodes=<numberOfNodes> -DvmSize=<vmSize> -DdmgrVMPrefix=<dmgrVMPrefix> -DmanagedVMPrefix=<managedVMPrefix> -DdnsLabelPrefix=<dnsLabelPrefix> -DadminUsername=<adminUsername> -DadminPasswordOrKey=<adminPassword|adminSSHPublicKey> -DauthenticationType=<password|sshPublicKey> -DwasUsername=<wasUsername> -DwasPassword=<wasPassword> -DconfigureIHS=<true|false> -DihsVmSize=<ihsVmSize> -DihsVMPrefix=<ihsVMPrefix> -DihsDnsLabelPrefix=<ihsDnsLabelPrefix> -DihsUnixUsername=<ihsUnixUsername> -DihsUnixPasswordOrKey=<ihsUnixPassword|ihsUnixSSHPublicKey> -DihsAuthenticationType=<password|sshPublicKey> -DihsAdminUsername=<ihsAdminUsername> -DihsAdminPassword=<ihsAdminPassword> -Dtest.args="-Test All" -Ptemplate-validation-tests clean install
    ```
 
 1. Change to `./target/arm` directory
@@ -38,3 +38,4 @@
    1. Open the resource group you specified to deploy WebSphere Cluster
    1. Navigate to "Deployments > specified_deployment_name > Outputs"
    1. Copy value of property `adminSecuredConsole` and browse it with credentials you specified in cluster creation
+   1. Copy value of property `ihsConsole` and open it in your browser if you selected to deploy IBM HTTP Server before

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
     <groupId>com.ibm.websphere.azure</groupId>
     <artifactId>azure.websphere-traditional.cluster</artifactId>
-    <version>1.3.15</version>
+    <version>1.3.16</version>
     
     <parent>
         <groupId>com.microsoft.azure.iaas</groupId>
@@ -47,12 +47,12 @@
         <!-- This is the twas-nd "Plan ID" of the plan within the "Azure Virtual Machine" offer -->
         <twasnd.image.sku>2021-04-27-twas-cluster-base-image</twasnd.image.sku>
         <!-- This is the twas-nd "Disk version" of the VM image of the plan within the "Azure Virtual Machine" offer -->
-        <twasnd.image.version>9.0.20210630</twasnd.image.version>
+        <twasnd.image.version>9.0.20210714</twasnd.image.version>
         <!-- This is the ihs "Offer ID" of the "Azure Virtual Machine" offer type -->
         <ihs.image.offer>2021-06-03-ihs-base-image</ihs.image.offer>
         <!-- This is the ihs "Plan ID" of the plan within the "Azure Virtual Machine" offer -->
         <ihs.image.sku>2021-06-03-ihs-base-image</ihs.image.sku>
         <!-- This is the ihs "Disk version" of the VM image of the plan within the "Azure Virtual Machine" offer -->
-        <ihs.image.version>9.0.20210630</ihs.image.version>
+        <ihs.image.version>9.0.20210714</ihs.image.version>
     </properties>
 </project>

--- a/src/main/arm/createUiDefinition.json
+++ b/src/main/arm/createUiDefinition.json
@@ -95,14 +95,15 @@
                     },
                     {
                         "name": "numberOfNodes",
-                        "type": "Microsoft.Common.TextBox",
+                        "type": "Microsoft.Common.Slider",
+                        "min": 2,
+                        "max": 21,
                         "label": "Number of VMs",
-                        "defaultValue": "4",
-                        "toolTip": "The number of virtual machines to create, with one deployment manager and one to four worker nodes.",
+                        "defaultValue": 4,
+                        "showStepMarkers": false,
+                        "toolTip": "The number of virtual machines to create, with one deployment manager and one to twenty worker nodes. More worker nodes usually need longer time to deploy.",
                         "constraints": {
-                            "required": true,
-                            "regex": "^(2|3|4|5)$",
-                            "validationMessage": "Please pick a value between 2 and 5. You need at least two virtual machines: one deployment manager and at least one worker node. The upper limit is five because this offer uses a single storage account."
+                            "required": true
                         }
                     },
                     {

--- a/src/main/arm/mainTemplate.json
+++ b/src/main/arm/mainTemplate.json
@@ -410,7 +410,9 @@
             "location": "[parameters('location')]",
             "copy": {
                 "name": "virtualMachineLoop",
-                "count": "[parameters('numberOfNodes')]"
+                "count": "[parameters('numberOfNodes')]",
+                "mode": "serial",
+                "batchSize": "[min(5, parameters('numberOfNodes'))]"
             },
             "dependsOn": [
                 "[resourceId('Microsoft.Network/networkInterfaces', concat(variables('name_dmgrVM'), '-if'))]",

--- a/src/main/scripts/configure-ihs-on-dmgr.sh
+++ b/src/main/scripts/configure-ihs-on-dmgr.sh
@@ -38,7 +38,6 @@ echo "password=$storageAccountKey" >> /etc/smbcredentials/${storageAccountName}.
 chmod 600 /etc/smbcredentials/${storageAccountName}.cred
 echo "//${storageAccountName}.file.core.windows.net/${fileShareName} $mountpointPath cifs nofail,vers=2.1,credentials=/etc/smbcredentials/${storageAccountName}.cred,dir_mode=0777,file_mode=0777,serverino" >> /etc/fstab
 
-yum install cifs-utils -y
 mount -t cifs //${storageAccountName}.file.core.windows.net/${fileShareName} $mountpointPath -o vers=2.1,credentials=/etc/smbcredentials/${storageAccountName}.cred,dir_mode=0777,file_mode=0777,serverino
 if [[ $? != 0 ]]; then
   echo "Failed to mount //${storageAccountName}.file.core.windows.net/${fileShareName} $mountpointPath"

--- a/src/main/scripts/configure-ihs.sh
+++ b/src/main/scripts/configure-ihs.sh
@@ -136,7 +136,6 @@ echo "password=$storageAccountKey" >> /etc/smbcredentials/${storageAccountName}.
 chmod 600 /etc/smbcredentials/${storageAccountName}.cred
 echo "//${storageAccountName}.file.core.windows.net/${fileShareName} $mountpointPath cifs nofail,vers=2.1,credentials=/etc/smbcredentials/${storageAccountName}.cred,dir_mode=0777,file_mode=0777,serverino" >> /etc/fstab
 
-yum install cifs-utils -y
 mount -t cifs //${storageAccountName}.file.core.windows.net/${fileShareName} $mountpointPath -o vers=2.1,credentials=/etc/smbcredentials/${storageAccountName}.cred,dir_mode=0777,file_mode=0777,serverino
 if [[ $? != 0 ]]; then
   echo "Failed to mount //${storageAccountName}.file.core.windows.net/${fileShareName} $mountpointPath"

--- a/src/main/scripts/configure-ihs.sh
+++ b/src/main/scripts/configure-ihs.sh
@@ -50,19 +50,23 @@ isDone=false
 while [ $isDone = false ]
 do
     result=`(tail -n1) </var/log/cloud-init-was.log`
-    if [[ $result = Unentitled ]] || [[ $result = Entitled ]]; then
+    if [[ $result = Entitled ]] || [[ $result = Unentitled ]] || [[ $result = Undefined ]]; then
         isDone=true
     else
         sleep 5
     fi
 done
-echo "The input IBMid account is ${result}."
 
 # Remove cloud-init artifacts and logs
 cloud-init clean --logs
 
-# Terminate the process for the un-entitled user
-if [ ${result} = Unentitled ]; then
+# Terminate the process for the un-entitled or undefined user
+if [ ${result} != Entitled ]; then
+    if [ ${result} = Unentitled ]; then
+        echo "The provided IBM ID does not have entitlement to install WebSphere Application Server. Please contact the primary or secondary contacts for your IBM Passport Advantage site to grant you access or follow steps at IBM eCustomer Care (https://www-112.ibm.com/software/howtobuy/passportadvantage/homepage/ecarec) for further assistance."
+    else
+        echo "No WebSphere Application Server installation packages were found. This is likely due to a temporary issue with the installation repository. Try again and open an IBM Support issue if the problem persists."
+    fi
     exit 1
 fi
 

--- a/src/main/scripts/configure-ihs.sh
+++ b/src/main/scripts/configure-ihs.sh
@@ -63,7 +63,7 @@ cloud-init clean --logs
 # Terminate the process for the un-entitled or undefined user
 if [ ${result} != Entitled ]; then
     if [ ${result} = Unentitled ]; then
-        echo "The provided IBM ID does not have entitlement to install WebSphere Application Server. Please contact the primary or secondary contacts for your IBM Passport Advantage site to grant you access or follow steps at IBM eCustomer Care (https://www-112.ibm.com/software/howtobuy/passportadvantage/homepage/ecarec) for further assistance."
+        echo "The provided IBM ID does not have entitlement to install WebSphere Application Server. Please contact the primary or secondary contacts for your IBM Passport Advantage site to grant you access or follow steps at IBM eCustomer Care (https://ibm.biz/IBMidEntitlement) for further assistance."
     else
         echo "No WebSphere Application Server installation packages were found. This is likely due to a temporary issue with the installation repository. Try again and open an IBM Support issue if the problem persists."
     fi

--- a/src/main/scripts/install.sh
+++ b/src/main/scripts/install.sh
@@ -246,7 +246,7 @@ cloud-init clean --logs
 # Terminate the process for the un-entitled or undefined user
 if [ ${result} != Entitled ]; then
     if [ ${result} = Unentitled ]; then
-        echo "The provided IBM ID does not have entitlement to install WebSphere Application Server. Please contact the primary or secondary contacts for your IBM Passport Advantage site to grant you access or follow steps at IBM eCustomer Care (https://www-112.ibm.com/software/howtobuy/passportadvantage/homepage/ecarec) for further assistance."
+        echo "The provided IBM ID does not have entitlement to install WebSphere Application Server. Please contact the primary or secondary contacts for your IBM Passport Advantage site to grant you access or follow steps at IBM eCustomer Care (https://ibm.biz/IBMidEntitlement) for further assistance."
     else
         echo "No WebSphere Application Server installation packages were found. This is likely due to a temporary issue with the installation repository. Try again and open an IBM Support issue if the problem persists."
     fi

--- a/src/main/scripts/install.sh
+++ b/src/main/scripts/install.sh
@@ -233,19 +233,23 @@ isDone=false
 while [ $isDone = false ]
 do
     result=`(tail -n1) </var/log/cloud-init-was.log`
-    if [[ $result = Unentitled ]] || [[ $result = Entitled ]]; then
+    if [[ $result = Entitled ]] || [[ $result = Unentitled ]] || [[ $result = Undefined ]]; then
         isDone=true
     else
         sleep 5
     fi
 done
-echo "The input IBMid account is ${result}."
 
 # Remove cloud-init artifacts and logs
 cloud-init clean --logs
 
-# Terminate the process for the un-entitled user
-if [ ${result} = Unentitled ]; then
+# Terminate the process for the un-entitled or undefined user
+if [ ${result} != Entitled ]; then
+    if [ ${result} = Unentitled ]; then
+        echo "The provided IBM ID does not have entitlement to install WebSphere Application Server. Please contact the primary or secondary contacts for your IBM Passport Advantage site to grant you access or follow steps at IBM eCustomer Care (https://www-112.ibm.com/software/howtobuy/passportadvantage/homepage/ecarec) for further assistance."
+    else
+        echo "No WebSphere Application Server installation packages were found. This is likely due to a temporary issue with the installation repository. Try again and open an IBM Support issue if the problem persists."
+    fi
     exit 1
 fi
 


### PR DESCRIPTION
## Summary

This is the 2nd PR sent to cluster repo to completely fix the following issues:
* Address part of #56
* Fix #85
* Fix #39
* Fix #35

The [1st PR](https://github.com/WASdev/azure.websphere-traditional.image/pull/42) sent to image repo has already been merged.

## Testing

* [Preview link](https://portal.azure.com/#create/microsoft_javaeeonazure_test.20191212-arm-rhel-was-nd-v9-cluster-previewwasndt91-n-cluster);
* Successfully deployed a cluster with 20 worker nodes and an IHS (took ~50 mins) using the above preview link, installed `DefaultApplication`, and visited the application using the IHS;
* Deployed with an invalid IBM ID and all of VMs are emptied as expected.

Signed-off-by: Jianguo Ma <jiangma@microsoft.com>