### PR TITLE
reference new base images which support RHEL 8_4

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # [Related: Base images deployed by this Azure application](https://github.com/WASdev/azure.websphere-traditional.image)
 
-# Deploy RHEL 8.3 VMs on Azure with IBM WebSphere Application Server ND Traditional V9.0.5 cluster and IBM HTTP Server V9.0 pre-installed
+# Deploy RHEL 8.4 VMs on Azure with IBM WebSphere Application Server ND Traditional V9.0.5 cluster and IBM HTTP Server V9.0 pre-installed
 
 ## Prerequisites
 
 1. Register an [Azure subscription](https://azure.microsoft.com/).
-1. The virtual machine offer which includes the image of RHEL8.3 with IBM WebSphere and JDK pre-installed is used as image reference to deploy virtual machine on Azure. Before the offer goes live in Azure Marketplace, your Azure subscription needs to be added into white list to successfully deploy VM using ARM template of this repo.
+1. The virtual machine offer which includes the image of RHEL 8.4 with IBM WebSphere and JDK pre-installed is used as image reference to deploy virtual machine on Azure. Before the offer goes live in Azure Marketplace, your Azure subscription needs to be added into white list to successfully deploy VM using ARM template of this repo.
 1. Install [Azure CLI](https://docs.microsoft.com/cli/azure/install-azure-cli?view=azure-cli-latest).
 1. Install [PowerShell Core](https://docs.microsoft.com/powershell/scripting/install/installing-powershell-core-on-linux?view=powershell-7.1).
 1. Install [Maven](https://maven.apache.org/download.cgi).

--- a/pom.xml
+++ b/pom.xml
@@ -47,12 +47,12 @@
         <!-- This is the twas-nd "Plan ID" of the plan within the "Azure Virtual Machine" offer -->
         <twasnd.image.sku>2021-04-27-twas-cluster-base-image</twasnd.image.sku>
         <!-- This is the twas-nd "Disk version" of the VM image of the plan within the "Azure Virtual Machine" offer -->
-        <twasnd.image.version>9.0.20210714</twasnd.image.version>
+        <twasnd.image.version>9.0.20210726</twasnd.image.version>
         <!-- This is the ihs "Offer ID" of the "Azure Virtual Machine" offer type -->
         <ihs.image.offer>2021-06-03-ihs-base-image</ihs.image.offer>
         <!-- This is the ihs "Plan ID" of the plan within the "Azure Virtual Machine" offer -->
         <ihs.image.sku>2021-06-03-ihs-base-image</ihs.image.sku>
         <!-- This is the ihs "Disk version" of the VM image of the plan within the "Azure Virtual Machine" offer -->
-        <ihs.image.version>9.0.20210714</ihs.image.version>
+        <ihs.image.version>9.0.20210726</ihs.image.version>
     </properties>
 </project>

--- a/src/main/resources/README.md
+++ b/src/main/resources/README.md
@@ -48,9 +48,9 @@
 - Summary
   - Provisions an n-node IBM WebSphere Application Server ND Traditional V9.0.5 Cluster
 - Long Summary
-  - Provisions an n-node IBM WebSphere Application Server ND Traditional V9.0.5 Cluster on RedHat Enterprise Linux 8.3
+  - Provisions an n-node IBM WebSphere Application Server ND Traditional V9.0.5 Cluster on RedHat Enterprise Linux 8.4
 - Description
-  - IBM WebSphere Application Server Network Deployment provides a flexible, secure server runtime environment for large-scale and mission critical application deployments. This offer provisions an n-node IBM WebSphere Application Server ND Traditional V9.0.5 Cluster on RedHat Enterprise Linux 8.3. ???
+  - IBM WebSphere Application Server Network Deployment provides a flexible, secure server runtime environment for large-scale and mission critical application deployments. This offer provisions an n-node IBM WebSphere Application Server ND Traditional V9.0.5 Cluster on RedHat Enterprise Linux 8.4. ???
 
 ### Legal Links
 
@@ -155,7 +155,7 @@
 - Summary
   - Provisions an n-node IBM WebSphere Application Server ND Traditional V9.0.5 Cluster
 - Description
-  - Provisions an n-node IBM WebSphere Application Server ND Traditional V9.0.5 Cluster on RedHat Enterprise Linux 8.3 VMs
+  - Provisions an n-node IBM WebSphere Application Server ND Traditional V9.0.5 Cluster on RedHat Enterprise Linux 8.4 VMs
 
 ### Availability
 


### PR DESCRIPTION
The following test cases are passed using the latest twas-nd and ihs base images (9.0.20210726):
* Successfully deployed a static cluster with 1 worker node and 1 IHS, using the entitled IBM ID. Verified that the cluster and IHS works by visiting the installed `DefaultApplication` using IP address of IHS VM.

Signed-off-by: Jianguo Ma <jiangma@microsoft.com>