### PR TITLE
fix failed to sign into ihs vm using ssh key

### DIFF
--- a/src/main/arm/createUiDefinition.json
+++ b/src/main/arm/createUiDefinition.json
@@ -9,7 +9,7 @@
                 "type": "Microsoft.Common.InfoBox",
                 "options": {
                     "icon": "Info",
-                    "text": "This offer is Bring-Your-Own-License. To deploy this offer, you must enter your registered IBM ID and your IBM ID must have active WebSphere entitlements associated with it. If provisioning fails due to lack of entitlements, ask the primary or secondary contacts for your IBM Passport Advantage site to grant you access or follow steps at <a href='https://www-112.ibm.com/software/howtobuy/passportadvantage/homepage/ecarec' target='_blank'>IBM eCustomer Care</a> for further assistance. This offer also assumes you are properly licensed to run offers in Microsoft Azure."
+                    "text": "This offer is Bring-Your-Own-License. To deploy this offer, you must enter your registered IBM ID and your IBM ID must have active WebSphere entitlements associated with it. If provisioning fails due to lack of entitlements, ask the primary or secondary contacts for your IBM Passport Advantage site to grant you access or follow steps at <a href='https://www-112.ibm.com/software/howtobuy/passportadvantage/homepage/ecarec?version=${project.version}' target='_blank'>IBM eCustomer Care</a> for further assistance. This offer also assumes you are properly licensed to run offers in Microsoft Azure."
                 }
             },
             {

--- a/src/main/arm/mainTemplate.json
+++ b/src/main/arm/mainTemplate.json
@@ -183,6 +183,17 @@
         "const_ihsArguments1": "[concat(' ',variables('name_dmgrVM'),' ',parameters('ihsUnixUsername'),' ',parameters('ihsAdminUsername'),' ',parameters('ihsAdminPassword'),' ',variables('name_storageAccount'))]",
         "const_ihsArguments2": "[concat(' ',variables('name_share'),' ',variables('const_mountPointPath'))]",
         "const_ihsDnsLabelPrefix": "[concat(parameters('ihsDnsLabelPrefix'), take(replace(parameters('guidValue'),'-',''),6))]",
+        "const_ihsLinuxConfiguration": {
+            "disablePasswordAuthentication": true,
+            "ssh": {
+                "publicKeys": [
+                    {
+                        "path": "[concat('/home/', parameters('ihsUnixUsername'), '/.ssh/authorized_keys')]",
+                        "keyData": "[parameters('ihsUnixPasswordOrKey')]"
+                    }
+                ]
+            }
+        },
         "const_linuxConfiguration": {
             "disablePasswordAuthentication": true,
             "ssh": {
@@ -604,7 +615,7 @@
                     "computerName": "[variables('name_ihsVM')]",
                     "adminUsername": "[parameters('ihsUnixUsername')]",
                     "adminPassword": "[parameters('ihsUnixPasswordOrKey')]",
-                    "linuxConfiguration": "[if(equals(parameters('ihsAuthenticationType'), 'password'), json('null'), variables('const_linuxConfiguration'))]",
+                    "linuxConfiguration": "[if(equals(parameters('ihsAuthenticationType'), 'password'), json('null'), variables('const_ihsLinuxConfiguration'))]",
                     "customData": "[base64(concat(parameters('ibmUserId'), ' ', parameters('ibmUserPwd')))]"
                 },
                 "networkProfile": {


### PR DESCRIPTION
## Change summary
* Fix #93;
* Append version info to the url of IBM eCustomer Care to get rid of the version info displayed in the bottom of the basic tab;

## Testing
* Deployed a cluster with public key as authentication type for both twas and ihs vms. Successfully `ssh` into twas and ihs vms using the private key.

Signed-off-by: Jianguo Ma <jiangma@microsoft.com>