### PR TITLE
move utility scripts to src/main/cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
    mvn -Dgit.repo=<repo_user> -Dgit.tag=<repo_tag> -DibmUserId=<ibmUserId> -DibmUserPwd=<ibmUserPwd> -Ddynamic=<true|false> -DnumberOfNodes=<numberOfNodes> -DvmSize=<vmSize> -DdmgrVMPrefix=<dmgrVMPrefix> -DmanagedVMPrefix=<managedVMPrefix> -DdnsLabelPrefix=<dnsLabelPrefix> -DadminUsername=<adminUsername> -DadminPasswordOrKey=<adminPassword|adminSSHPublicKey> -DauthenticationType=<password|sshPublicKey> -DwasUsername=<wasUsername> -DwasPassword=<wasPassword> -DconfigureIHS=<true|false> -DihsVmSize=<ihsVmSize> -DihsVMPrefix=<ihsVMPrefix> -DihsDnsLabelPrefix=<ihsDnsLabelPrefix> -DihsUnixUsername=<ihsUnixUsername> -DihsUnixPasswordOrKey=<ihsUnixPassword|ihsUnixSSHPublicKey> -DihsAuthenticationType=<password|sshPublicKey> -DihsAdminUsername=<ihsAdminUsername> -DihsAdminPassword=<ihsAdminPassword> -Dtest.args="-Test All" -Ptemplate-validation-tests clean install
    ```
 
-1. Change to `./target/arm` directory
+1. Change to `./target/cli` directory
 1. Using `deploy.azcli` to deploy
 
    ```bash

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>com.microsoft.azure.iaas</groupId>
         <artifactId>azure-javaee-iaas-parent</artifactId>
-        <version>1.0.7</version>
+        <version>1.0.11</version>
         <relativePath></relativePath>
     </parent>
     

--- a/src/main/cli/deploy.azcli
+++ b/src/main/cli/deploy.azcli
@@ -82,7 +82,7 @@ if [ -z "$deploymentName" ] || [ -z "$subscriptionId" ] || [ -z "$resourceGroupN
 fi
 
 #templateFile Path - template file to be used
-templateFilePath="mainTemplate.json"
+templateFilePath="../arm/mainTemplate.json"
 
 if [ ! -f "$templateFilePath" ]; then
 	echo "$templateFilePath not found"
@@ -90,7 +90,7 @@ if [ ! -f "$templateFilePath" ]; then
 fi
 
 #parameter file path
-parametersFilePath="parameters.json"
+parametersFilePath="../arm/parameters.json"
 
 if [ ! -f "$parametersFilePath" ]; then
 	echo "$parametersFilePath not found"


### PR DESCRIPTION
With pull request Azure/azure-javaee-iaas#20 is merged, it's time to move utility scripts that're not part of deployment scripts included in the offer to `src/main/cli` for better organization of code structure.

Signed-off-by: Jianguo Ma <jiangma@microsoft.com>