### PR TITLE
Add timestamps for profile creation, cluster creation and ihs configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
     <groupId>com.ibm.websphere.azure</groupId>
     <artifactId>azure.websphere-traditional.cluster</artifactId>
-    <version>1.3.19</version>
+    <version>1.3.20</version>
     
     <parent>
         <groupId>com.microsoft.azure.iaas</groupId>

--- a/src/main/arm/mainTemplate.json
+++ b/src/main/arm/mainTemplate.json
@@ -487,6 +487,23 @@
             }
         },
         {
+            "type": "Microsoft.Resources/deployments",
+            "apiVersion": "${azure.apiVersion}",
+            "name": "clusterVMsCreated",
+            "dependsOn": [
+                "virtualMachineLoop"
+            ],
+            "properties": {
+                "mode": "Incremental",
+                "template": {
+                    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                    "contentVersion": "1.0.0.0",
+                    "resources": [
+                    ]
+                }
+            }
+        },
+        {
             "type": "Microsoft.Compute/virtualMachines/extensions",
             "apiVersion": "${azure.apiVersion}",
             "name": "[concat(if(equals(copyIndex(), 0), variables('name_dmgrVM'), concat(variables('const_managedVMPrefix'), copyIndex())), '/install')]",
@@ -647,6 +664,23 @@
                 "name": "${ihs.image.sku}",
                 "publisher": "${image.publisher}",
                 "product": "${ihs.image.offer}"
+            }
+        },
+        {
+            "type": "Microsoft.Resources/deployments",
+            "apiVersion": "${azure.apiVersion}",
+            "name": "ihsVMCreated",
+            "dependsOn": [
+                "[resourceId('Microsoft.Compute/virtualMachines/', variables('name_ihsVM'))]"
+            ],
+            "properties": {
+                "mode": "Incremental",
+                "template": {
+                    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                    "contentVersion": "1.0.0.0",
+                    "resources": [
+                    ]
+                }
             }
         },
         {

--- a/src/main/scripts/configure-ihs-on-dmgr.sh
+++ b/src/main/scripts/configure-ihs-on-dmgr.sh
@@ -28,6 +28,8 @@ storageAccountKey=$5
 fileShareName=$6
 mountpointPath=$7
 
+echo "$(date): Start to configure IHS on dmgr."
+
 source /datadrive/virtualimage.properties
 
 # Mount Azure File Share system
@@ -40,7 +42,7 @@ echo "//${storageAccountName}.file.core.windows.net/${fileShareName} $mountpoint
 
 mount -t cifs //${storageAccountName}.file.core.windows.net/${fileShareName} $mountpointPath -o credentials=/etc/smbcredentials/${storageAccountName}.cred,dir_mode=0777,file_mode=0777,serverino
 if [[ $? != 0 ]]; then
-  echo "Failed to mount //${storageAccountName}.file.core.windows.net/${fileShareName} $mountpointPath"
+  echo "$(date): Failed to mount //${storageAccountName}.file.core.windows.net/${fileShareName} $mountpointPath."
   exit 1
 fi
 
@@ -52,7 +54,7 @@ do
 done
 mv $mountpointPath/configurewebserver1.sh $WAS_ND_INSTALL_DIRECTORY/bin
 if [[ $? != 0 ]]; then
-  echo "Failed to move $mountpointPath/configurewebserver1.sh to $WAS_ND_INSTALL_DIRECTORY/bin"
+  echo "$(date): Failed to move $mountpointPath/configurewebserver1.sh to $WAS_ND_INSTALL_DIRECTORY/bin."
   exit 1
 fi
 
@@ -60,7 +62,6 @@ fi
 read -r -a cmds <<<`(tail -n1) <$WAS_ND_INSTALL_DIRECTORY/bin/configurewebserver1.sh`
 nodeName=${cmds[14]}
 
-echo "Configure IHS on the DMgr"
 $WAS_ND_INSTALL_DIRECTORY/bin/configurewebserver1.sh -profileName $profile -user $wasUser -password $wasPassword >/dev/null 2>&1
 rm -rf $WAS_ND_INSTALL_DIRECTORY/bin/configurewebserver1.sh
 
@@ -73,3 +74,5 @@ $WAS_ND_INSTALL_DIRECTORY/bin/pluginutil.sh generate webserver1 $nodeName
 $WAS_ND_INSTALL_DIRECTORY/bin/pluginutil.sh propagate webserver1 $nodeName
 $WAS_ND_INSTALL_DIRECTORY/bin/pluginutil.sh propagateKeyring webserver1 $nodeName
 $WAS_ND_INSTALL_DIRECTORY/bin/pluginutil.sh restart webserver1 $nodeName
+
+echo "$(date): Complete to configure IHS on dmgr."

--- a/src/main/scripts/configure-ihs.sh
+++ b/src/main/scripts/configure-ihs.sh
@@ -40,8 +40,11 @@ EOF
   systemctl enable "$srvName"
 }
 
+# Get IHS installation properties
+source /datadrive/virtualimage.properties
+
 # Check whether the user is entitled or not
-while [ ! -f "/var/log/cloud-init-was.log" ]
+while [ ! -f "$WAS_LOG_PATH" ]
 do
     sleep 5
 done
@@ -49,8 +52,8 @@ done
 isDone=false
 while [ $isDone = false ]
 do
-    result=`(tail -n1) </var/log/cloud-init-was.log`
-    if [[ $result = Entitled ]] || [[ $result = Unentitled ]] || [[ $result = Undefined ]]; then
+    result=`(tail -n1) <$WAS_LOG_PATH`
+    if [[ $result = $ENTITLED ]] || [[ $result = $UNENTITLED ]] || [[ $result = $UNDEFINED ]]; then
         isDone=true
     else
         sleep 5
@@ -61,8 +64,8 @@ done
 cloud-init clean --logs
 
 # Terminate the process for the un-entitled or undefined user
-if [ ${result} != Entitled ]; then
-    if [ ${result} = Unentitled ]; then
+if [ ${result} != $ENTITLED ]; then
+    if [ ${result} = $UNENTITLED ]; then
         echo "The provided IBM ID does not have entitlement to install WebSphere Application Server. Please contact the primary or secondary contacts for your IBM Passport Advantage site to grant you access or follow steps at IBM eCustomer Care (https://ibm.biz/IBMidEntitlement) for further assistance."
     else
         echo "No WebSphere Application Server installation packages were found. This is likely due to a temporary issue with the installation repository. Try again and open an IBM Support issue if the problem persists."
@@ -86,9 +89,6 @@ fileShareName=$7
 mountpointPath=$8
 
 echo "$(date): Start to configure IHS."
-
-# Get IHS installation properties
-source /datadrive/virtualimage.properties
 
 # Open ports
 firewall-cmd --zone=public --add-port=80/tcp --permanent

--- a/src/main/scripts/configure-ihs.sh
+++ b/src/main/scripts/configure-ihs.sh
@@ -85,6 +85,8 @@ storageAccountKey=$6
 fileShareName=$7
 mountpointPath=$8
 
+echo "$(date): Start to configure IHS."
+
 # Get IHS installation properties
 source /datadrive/virtualimage.properties
 
@@ -138,13 +140,15 @@ echo "//${storageAccountName}.file.core.windows.net/${fileShareName} $mountpoint
 
 mount -t cifs //${storageAccountName}.file.core.windows.net/${fileShareName} $mountpointPath -o credentials=/etc/smbcredentials/${storageAccountName}.cred,dir_mode=0777,file_mode=0777,serverino
 if [[ $? != 0 ]]; then
-  echo "Failed to mount //${storageAccountName}.file.core.windows.net/${fileShareName} $mountpointPath"
+  echo "$(date): Failed to mount //${storageAccountName}.file.core.windows.net/${fileShareName} $mountpointPath."
   exit 1
 fi
 
 # Move the IHS confguration script to Azure File Share system
 mv $PLUGIN_INSTALL_DIRECTORY/bin/configurewebserver1.sh $mountpointPath
 if [[ $? != 0 ]]; then
-  echo "Failed to move $PLUGIN_INSTALL_DIRECTORY/bin/configurewebserver1.sh to $mountpointPath"
+  echo "$(date): Failed to move $PLUGIN_INSTALL_DIRECTORY/bin/configurewebserver1.sh to $mountpointPath."
   exit 1
 fi
+
+echo "$(date): Complete to configure IHS."

--- a/src/main/scripts/install.sh
+++ b/src/main/scripts/install.sh
@@ -215,8 +215,11 @@ create_custom_profile() {
     echo "$(date): Custom profile created."
 }
 
+# Get tWAS installation properties
+source /datadrive/virtualimage.properties
+
 # Check whether the user is entitled or not
-while [ ! -f "/var/log/cloud-init-was.log" ]
+while [ ! -f "$WAS_LOG_PATH" ]
 do
     sleep 5
 done
@@ -224,8 +227,8 @@ done
 isDone=false
 while [ $isDone = false ]
 do
-    result=`(tail -n1) </var/log/cloud-init-was.log`
-    if [[ $result = Entitled ]] || [[ $result = Unentitled ]] || [[ $result = Undefined ]]; then
+    result=`(tail -n1) <$WAS_LOG_PATH`
+    if [[ $result = $ENTITLED ]] || [[ $result = $UNENTITLED ]] || [[ $result = $UNDEFINED ]]; then
         isDone=true
     else
         sleep 5
@@ -236,8 +239,8 @@ done
 cloud-init clean --logs
 
 # Terminate the process for the un-entitled or undefined user
-if [ ${result} != Entitled ]; then
-    if [ ${result} = Unentitled ]; then
+if [ ${result} != $ENTITLED ]; then
+    if [ ${result} = $UNENTITLED ]; then
         echo "The provided IBM ID does not have entitlement to install WebSphere Application Server. Please contact the primary or secondary contacts for your IBM Passport Advantage site to grant you access or follow steps at IBM eCustomer Care (https://ibm.biz/IBMidEntitlement) for further assistance."
     else
         echo "No WebSphere Application Server installation packages were found. This is likely due to a temporary issue with the installation repository. Try again and open an IBM Support issue if the problem persists."
@@ -266,9 +269,6 @@ storageAccountName=$8
 storageAccountKey=$9
 fileShareName=${10}
 mountpointPath=${11}
-
-# Get tWAS installation properties
-source /datadrive/virtualimage.properties
 
 # Create cluster by creating deployment manager, node agent & add nodes to be managed
 if [ "$dmgr" = True ]; then


### PR DESCRIPTION
## Description

This is the 2nd PR to resolve #105, which depends on [another PR](https://github.com/WASdev/azure.websphere-traditional.image/pull/47) opened in the image repo.

## Change summary

* Add timestamps for profile creation, cluster creation and ihs configuration
* Use properties instead of hard-coded values

## Testing

The following test cases have been passed before opening the above two PRs:
* Successfully created twas-nd and ihs private VM images based on image repo;
* Successfully created a tWAS cluster (1 dmgr, 1 worker node & 1 IHS) by referencing the private images with an entitled IBMid. 
  * User can then successfully deploy a default application `DefaultApplication` to the cluster and IHS, which is accessible later;
* Created an empty tWAS cluster (1 dmgr, 1 worker node & 1 IHS) by referencing the private images with an invalid IBMid.
   * SSH into VMs and verified that WAS installation is removed from all VMs
* SSH into VMs and verified that logs are recorded with timestamps.

Signed-off-by: Jianguo Ma <jiangma@microsoft.com>