### PR TITLE
Support entitlement and evaluation editions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,12 +52,12 @@
         <!-- This is the twas-nd "Plan ID" of the plan within the "Azure Virtual Machine" offer -->
         <twasnd.image.sku>2021-04-27-twas-cluster-base-image</twasnd.image.sku>
         <!-- This is the twas-nd "Disk version" of the VM image of the plan within the "Azure Virtual Machine" offer -->
-        <twasnd.image.version>9.0.20220209</twasnd.image.version>
+        <twasnd.image.version>9.0.20220303</twasnd.image.version>
         <!-- This is the ihs "Offer ID" of the "Azure Virtual Machine" offer type -->
         <ihs.image.offer>2021-06-03-ihs-base-image</ihs.image.offer>
         <!-- This is the ihs "Plan ID" of the plan within the "Azure Virtual Machine" offer -->
         <ihs.image.sku>2021-06-03-ihs-base-image</ihs.image.sku>
         <!-- This is the ihs "Disk version" of the VM image of the plan within the "Azure Virtual Machine" offer -->
-        <ihs.image.version>9.0.20220209</ihs.image.version>
+        <ihs.image.version>9.0.20220303</ihs.image.version>
     </properties>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
     <groupId>com.ibm.websphere.azure</groupId>
     <artifactId>azure.websphere-traditional.cluster</artifactId>
-    <version>1.3.29</version>
+    <version>1.3.30</version>
     
     <parent>
         <groupId>com.microsoft.azure.iaas</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,10 @@
         <cluster.end>9c5dbfce-a6b9-5659-96bc-ca0cf429122a</cluster.end>
         <ihs.start>5526bacf-3c35-57b7-8b22-337d78b4f478</ihs.start>
         <ihs.end>3720d7ef-c2dc-5ad4-83bc-96e54bd2bd13</ihs.end>
+        <cluster.trial.start>e71b564d-20cf-5fc6-a5f5-dc4857c8311b</cluster.trial.start>
+        <cluster.trial.end>97aa2bca-c9ae-523f-a577-210a0a32c88a</cluster.trial.end>
+        <ihs.trial.start>2a3847d2-c1fa-583e-bb90-c483d43ad131</ihs.trial.start>
+        <ihs.trial.end>a9365407-7f6b-5b78-9b51-2d76e9888a21</ihs.trial.end>
         <!-- This is the "Partner ID" in Partner Center" -->
         <image.publisher>ibm-usa-ny-armonk-hq-6275750-ibmcloud-aiops</image.publisher>
         <!-- This is the twas-nd "Offer ID" of the "Azure Virtual Machine" offer type -->

--- a/src/main/arm/createUiDefinition.json
+++ b/src/main/arm/createUiDefinition.json
@@ -25,12 +25,13 @@
                 }
             },
             {
-                "name": "entitlementInfo",
+                "name": "ibmIdInfo",
                 "type": "Microsoft.Common.InfoBox",
                 "options": {
                     "icon": "Info",
-                    "text": "[if(bool(basics('useTrial')), 'TBD text will contain points such as: 1) BIG BOLD NO iFixes warning. 2) The trial is 60 days in duration.', 'This offer is Bring-Your-Own-License. To deploy this offer, you must enter your registered IBMid and your IBMid must have active WebSphere entitlements associated with it. If provisioning fails due to lack of entitlements, ask the primary or secondary contacts for your IBM Passport Advantage site to grant you access or follow steps at <a href=\"https://ibm.biz/IBMidEntitlement\" target=\"_blank\">IBM eCustomer Care</a> for further assistance. This offer also assumes you are properly licensed to run offers in Microsoft Azure.')]"
-                }
+                    "text": "This offer is Bring-Your-Own-License. To deploy this offer, you must enter your registered IBMid and your IBMid must have active WebSphere entitlements associated with it. If provisioning fails due to lack of entitlements, ask the primary or secondary contacts for your IBM Passport Advantage site to grant you access or follow steps at <a href='https://ibm.biz/IBMidEntitlement' target='_blank'>IBM eCustomer Care</a> for further assistance. This offer also assumes you are properly licensed to run offers in Microsoft Azure."
+                },
+                "visible": "[not(bool(basics('useTrial')))]"
             },
             {
                 "name": "ibmUserId",
@@ -62,13 +63,13 @@
                 "type": "Microsoft.Common.InfoBox",
                 "options": {
                     "icon": "Info",
-                    "text": "Accept the IBM License Agreement to proceed with the deployment. <a href='https://ibm.biz/tWASNDLicenseAzureVMs' target='_blank'>IBM WebSphere Application Server Network Deployment</a>."
+                    "text": "[concat(if(bool(basics('useTrial')), 'By accepting the IBM License Agreement you are accepting the Evaluation terms of the license. An evaluation deployment does not include WebSphere interim fixes (iFixes). The evaluation period runs for 60 days after which you must purchase entitlement to continue to use WebSphere.', 'Accept the IBM License Agreement to proceed with the deployment.'), ' <a href=\"https://ibm.biz/tWASBaseLicenseAzureVMs\" target=\"_blank\">IBM WebSphere Application Server</a>.')]"
                 }
             },
             {
                 "name": "acceptIBMLicenseAgreement",
                 "type": "Microsoft.Common.CheckBox",
-                "label": "I accept the IBM License Agreement.",
+                "label": "I have read and accept the IBM License Agreement.",
                 "toolTip": "Select to accept the IBM License Agreement.",
                 "constraints": {
                     "required": true,

--- a/src/main/arm/createUiDefinition.json
+++ b/src/main/arm/createUiDefinition.json
@@ -5,11 +5,31 @@
     "parameters": {
         "basics": [
             {
-                "name": "ibmIdInfo",
+                "name": "useTrial",
+                "type": "Microsoft.Common.OptionsGroup",
+                "label": "Deploy with existing WebSphere entitlement or with evaluation license?",
+                "toolTip": "Select to deploy with existing WebSphere entitlement or with evaluation license.",
+                "defaultValue": "Entitled",
+                "constraints": {
+                    "allowedValues": [
+                        {
+                            "label": "Entitled",
+                            "value": "false"
+                        },
+                        {
+                            "label": "Evaluation",
+                            "value": "true"
+                        }
+                    ],
+                    "required": true
+                }
+            },
+            {
+                "name": "entitlementInfo",
                 "type": "Microsoft.Common.InfoBox",
                 "options": {
                     "icon": "Info",
-                    "text": "This offer is Bring-Your-Own-License. To deploy this offer, you must enter your registered IBMid and your IBMid must have active WebSphere entitlements associated with it. If provisioning fails due to lack of entitlements, ask the primary or secondary contacts for your IBM Passport Advantage site to grant you access or follow steps at <a href='https://ibm.biz/IBMidEntitlement' target='_blank'>IBM eCustomer Care</a> for further assistance. This offer also assumes you are properly licensed to run offers in Microsoft Azure."
+                    "text": "[if(bool(basics('useTrial')), 'TBD text will contain points such as: 1) BIG BOLD NO iFixes warning. 2) The trial is 60 days in duration.', 'This offer is Bring-Your-Own-License. To deploy this offer, you must enter your registered IBMid and your IBMid must have active WebSphere entitlements associated with it. If provisioning fails due to lack of entitlements, ask the primary or secondary contacts for your IBM Passport Advantage site to grant you access or follow steps at <a href=\"https://ibm.biz/IBMidEntitlement\" target=\"_blank\">IBM eCustomer Care</a> for further assistance. This offer also assumes you are properly licensed to run offers in Microsoft Azure.')]"
                 }
             },
             {
@@ -21,7 +41,8 @@
                     "required": true,
                     "regex": "^(?!\\-)([a-z0-9A-Z@\\-]{1,128})([^\\-])",
                     "validationMessage": "The value must be valid IBMid."
-                }
+                },
+                "visible": "[not(bool(basics('useTrial')))]"
             },
             {
                 "name": "ibmUserPwd",
@@ -33,7 +54,8 @@
                 "toolTip": "Password for your IBMid.",
                 "constraints": {
                     "required": true
-                }
+                },
+                "visible": "[not(bool(basics('useTrial')))]"
             },
             {
                 "name": "licenseInfo",
@@ -393,6 +415,7 @@
         ],
         "outputs": {
             "location": "[location()]",
+            "useTrial": "[bool(basics('useTrial'))]",
             "ibmUserId": "[basics('ibmUserId')]",
             "ibmUserPwd": "[basics('ibmUserPwd')]",
             "numberOfNodes": "[int(steps('ClusterConfig').numberOfNodes)]",

--- a/src/main/arm/mainTemplate.json
+++ b/src/main/arm/mainTemplate.json
@@ -23,6 +23,12 @@
                 "description": "Location for all resources."
             }
         },
+        "useTrial": {
+            "type": "bool",
+            "metadata": {
+                "description": "Boolean value indicating, if use wants to deploy a tWAS cluster for evaluation only."
+            }
+        },
         "ibmUserId": {
             "type": "string",
             "defaultValue": "",
@@ -249,7 +255,7 @@
         {
             "type": "Microsoft.Resources/deployments",
             "apiVersion": "${azure.apiVersion}",
-            "name": "${cluster.start}",
+            "name": "[if(parameters('useTrial'), '${cluster.trial.start}', '${cluster.start}')]",
             "properties": {
                 "mode": "Incremental",
                 "template": {
@@ -467,7 +473,7 @@
                     "adminUsername": "[parameters('adminUsername')]",
                     "adminPassword": "[parameters('adminPasswordOrKey')]",
                     "linuxConfiguration": "[if(equals(parameters('authenticationType'), 'password'), json('null'), variables('const_linuxConfiguration'))]",
-                    "customData": "[base64(concat(parameters('ibmUserId'), ' ', parameters('ibmUserPwd')))]"
+                    "customData": "[base64(if(parameters('useTrial'), ' ', concat(parameters('ibmUserId'), ' ', parameters('ibmUserPwd'))))]"
                 },
                 "networkProfile": {
                     "networkInterfaces": [
@@ -542,7 +548,7 @@
         {
             "type": "Microsoft.Resources/deployments",
             "apiVersion": "${azure.apiVersion}",
-            "name": "${cluster.end}",
+            "name": "[if(parameters('useTrial'), '${cluster.trial.end}', '${cluster.end}')]",
             "dependsOn": [
                 "virtualMachineExtensionLoop"
             ],
@@ -560,7 +566,7 @@
             "condition": "[parameters('configureIHS')]",
             "type": "Microsoft.Resources/deployments",
             "apiVersion": "${azure.apiVersion}",
-            "name": "${ihs.start}",
+            "name": "[if(parameters('useTrial'), '${ihs.trial.start}', '${ihs.start}')]",
             "properties": {
                 "mode": "Incremental",
                 "template": {
@@ -647,7 +653,7 @@
                     "adminUsername": "[parameters('ihsUnixUsername')]",
                     "adminPassword": "[parameters('ihsUnixPasswordOrKey')]",
                     "linuxConfiguration": "[if(equals(parameters('ihsAuthenticationType'), 'password'), json('null'), variables('const_ihsLinuxConfiguration'))]",
-                    "customData": "[base64(concat(parameters('ibmUserId'), ' ', parameters('ibmUserPwd')))]"
+                    "customData": "[base64(if(parameters('useTrial'), ' ', concat(parameters('ibmUserId'), ' ', parameters('ibmUserPwd'))))]"
                 },
                 "networkProfile": {
                     "networkInterfaces": [
@@ -716,7 +722,7 @@
             "condition": "[parameters('configureIHS')]",
             "type": "Microsoft.Resources/deployments",
             "apiVersion": "${azure.apiVersion}",
-            "name": "${ihs.end}",
+            "name": "[if(parameters('useTrial'), '${ihs.trial.end}', '${ihs.end}')]",
             "dependsOn": [
                 "[resourceId('Microsoft.Compute/virtualMachines/extensions', variables('name_ihsVM'), 'install')]"
             ],

--- a/src/main/arm/mainTemplate.json
+++ b/src/main/arm/mainTemplate.json
@@ -25,12 +25,14 @@
         },
         "ibmUserId": {
             "type": "string",
+            "defaultValue": "",
             "metadata": {
                 "description": "Username of your IBMid account."
             }
         },
         "ibmUserPwd": {
             "type": "securestring",
+            "defaultValue": "",
             "metadata": {
                 "description": "Password of your IBMid account."
             }

--- a/src/main/arm/mainTemplate.json
+++ b/src/main/arm/mainTemplate.json
@@ -26,7 +26,7 @@
         "useTrial": {
             "type": "bool",
             "metadata": {
-                "description": "Boolean value indicating, if use wants to deploy a tWAS cluster for evaluation only."
+                "description": "Boolean value indicating, if user wants to deploy a tWAS cluster for evaluation only."
             }
         },
         "ibmUserId": {

--- a/src/main/arm/parameters.json
+++ b/src/main/arm/parameters.json
@@ -5,6 +5,9 @@
         "_artifactsLocation": {
             "value": "${artifactsLocationBase}/${project.artifactId}/${git.tag}/src/main/"
         },
+        "useTrial": {
+            "value": "${useTrial}"
+        },
         "ibmUserId": {
             "value": "${ibmUserId}"
         },

--- a/src/main/cli/deploy.azcli
+++ b/src/main/cli/deploy.azcli
@@ -126,6 +126,8 @@ resourceGroupLocation=$( az group show --name $resourceGroupName | jq -r '.locat
 
 #parameters JSON
 parametersJson=$( cat $parametersFilePath | jq '.parameters' )
+useTrial=$( echo $parametersJson | jq '.useTrial.value' | sed 's/"//g' )
+parametersJson=$( echo $parametersJson | jq --argjson useTrial "$useTrial" '.useTrial.value = $useTrial' )
 numberOfNodes=$( echo $parametersJson | jq '.numberOfNodes.value' | sed 's/"//g' )
 parametersJson=$( echo $parametersJson | jq --argjson cnt "$numberOfNodes" '.numberOfNodes.value = $cnt' )
 configureIHS=$( echo $parametersJson | jq '.configureIHS.value' | sed 's/"//g' )

--- a/src/main/scripts/configure-ihs.sh
+++ b/src/main/scripts/configure-ihs.sh
@@ -53,7 +53,7 @@ isDone=false
 while [ $isDone = false ]
 do
     result=`(tail -n1) <$WAS_LOG_PATH`
-    if [[ $result = $ENTITLED ]] || [[ $result = $UNENTITLED ]] || [[ $result = $UNDEFINED ]]; then
+    if [[ $result = $ENTITLED ]] || [[ $result = $UNENTITLED ]] || [[ $result = $UNDEFINED ]] || [[ $result = $EVALUATION ]]; then
         isDone=true
     else
         sleep 5
@@ -64,7 +64,7 @@ done
 cloud-init clean --logs
 
 # Terminate the process for the un-entitled or undefined user
-if [ ${result} != $ENTITLED ]; then
+if [ ${result} != $ENTITLED ] && [ ${result} != $EVALUATION ]; then
     if [ ${result} = $UNENTITLED ]; then
         echo "The provided IBMid does not have entitlement to install WebSphere Application Server. Please contact the primary or secondary contacts for your IBM Passport Advantage site to grant you access or follow steps at IBM eCustomer Care (https://ibm.biz/IBMidEntitlement) for further assistance."
     else

--- a/src/main/scripts/install.sh
+++ b/src/main/scripts/install.sh
@@ -228,7 +228,7 @@ isDone=false
 while [ $isDone = false ]
 do
     result=`(tail -n1) <$WAS_LOG_PATH`
-    if [[ $result = $ENTITLED ]] || [[ $result = $UNENTITLED ]] || [[ $result = $UNDEFINED ]]; then
+    if [[ $result = $ENTITLED ]] || [[ $result = $UNENTITLED ]] || [[ $result = $UNDEFINED ]] || [[ $result = $EVALUATION ]]; then
         isDone=true
     else
         sleep 5
@@ -239,7 +239,7 @@ done
 cloud-init clean --logs
 
 # Terminate the process for the un-entitled or undefined user
-if [ ${result} != $ENTITLED ]; then
+if [ ${result} != $ENTITLED ] && [ ${result} != $EVALUATION ]; then
     if [ ${result} = $UNENTITLED ]; then
         echo "The provided IBMid does not have entitlement to install WebSphere Application Server. Please contact the primary or secondary contacts for your IBM Passport Advantage site to grant you access or follow steps at IBM eCustomer Care (https://ibm.biz/IBMidEntitlement) for further assistance."
     else


### PR DESCRIPTION
## Description

The PR is to resolve #140 and resolve #141 so that the twas-cluster offer can support both entitlement and evaluation usages.

## Testing

The following test cases are passed before sending out the PR:
* Deployment in **Entitled** mode:
   * Successfully deployed a tWAS nd cluster on Azure VMs using an entitled IBMid
   * Failed to deploy a tWAS nd cluster on Azure VMs using an invalid IBMid
* Deployment in **Evaluation license** mode:
   * Successfully deployed a tWAS nd cluster on Azure VMs without IBMid

Here is the [preview link](https://portal.azure.com/#create/microsoft_javaeeonazure_test.20191212-arm-rhel-was-nd-v9-cluster-previewwasndt91-n-cluster) for live testing.

Signed-off-by: Jianguo Ma [jiangma@microsoft.com](mailto:jiangma@microsoft.com)