### PR TITLE
Bring your own VNet

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,12 @@
 1. Checkout [azure-javaee-iaas](https://github.com/Azure/azure-javaee-iaas)
    1. Change to directory hosting the repo project & run `mvn clean install`
 1. Checkout [arm-ttk](https://github.com/Azure/arm-ttk) under the specified parent directory
+   1. Run `git checkout cf5c927eaf1f5652556e86a6b67816fc910d1b74` to checkout the verified version of `arm-ttk`
 1. Checkout this repo under the same parent directory and change to directory hosting the repo project
 1. Build the project by replacing all placeholder `${<place_holder>}` with valid values
 
    ```bash
-   mvn -Dgit.repo=<repo_user> -Dgit.tag=<repo_tag> -DibmUserId=<ibmUserId> -DibmUserPwd=<ibmUserPwd> -DnumberOfNodes=<numberOfNodes> -DvmSize=<vmSize> -DdmgrVMPrefix=<dmgrVMPrefix> -DmanagedVMPrefix=<managedVMPrefix> -DdnsLabelPrefix=<dnsLabelPrefix> -DadminUsername=<adminUsername> -DadminPasswordOrKey=<adminPassword|adminSSHPublicKey> -DauthenticationType=<password|sshPublicKey> -DwasUsername=<wasUsername> -DwasPassword=<wasPassword> -DconfigureIHS=<true|false> -DihsVmSize=<ihsVmSize> -DihsVMPrefix=<ihsVMPrefix> -DihsDnsLabelPrefix=<ihsDnsLabelPrefix> -DihsUnixUsername=<ihsUnixUsername> -DihsUnixPasswordOrKey=<ihsUnixPassword|ihsUnixSSHPublicKey> -DihsAuthenticationType=<password|sshPublicKey> -DihsAdminUsername=<ihsAdminUsername> -DihsAdminPassword=<ihsAdminPassword> -Dtest.args="-Test All" -Ptemplate-validation-tests clean install
+   mvn -Dgit.repo=<repo_user> -Dgit.tag=<repo_tag> -DuseTrial=true -DnumberOfNodes=<numberOfNodes> -DvmSize=<vmSize> -DdmgrVMPrefix=<dmgrVMPrefix> -DmanagedVMPrefix=<managedVMPrefix> -DdnsLabelPrefix=<dnsLabelPrefix> -DadminUsername=<adminUsername> -DadminPasswordOrKey=<adminPassword|adminSSHPublicKey> -DauthenticationType=<password|sshPublicKey> -DwasUsername=<wasUsername> -DwasPassword=<wasPassword> -DconfigureIHS=<true|false> -DihsVmSize=<ihsVmSize> -DihsVMPrefix=<ihsVMPrefix> -DihsDnsLabelPrefix=<ihsDnsLabelPrefix> -DihsUnixUsername=<ihsUnixUsername> -DihsUnixPasswordOrKey=<ihsUnixPassword|ihsUnixSSHPublicKey> -DihsAuthenticationType=<password|sshPublicKey> -DihsAdminUsername=<ihsAdminUsername> -DihsAdminPassword=<ihsAdminPassword> -Dtest.args="-Test All" -Pbicep -Passembly -Ptemplate-validation-tests clean install
    ```
 
 1. Change to `./target/cli` directory

--- a/docs/howto-update-for-was-fixpack.md
+++ b/docs/howto-update-for-was-fixpack.md
@@ -66,7 +66,7 @@ Please follow sections below in order to update the solution for next tWAS fixpa
    Note: Currently Graham Charters has privilege to update the image in marketplace, contact him for more information.
 
 1. Do we need to update the solution every time we do the image update?
-   * Yes. That's because image versions of [`twas-nd`](https://github.com/WASdev/azure.websphere-traditional.cluster/blob/main/src/main/bicep/config.json#L18) and [`ihs`](https://github.com/WASdev/azure.websphere-traditional.cluster/blob/main/src/main/bicep/config.json#L24) are explicitely referenced in the tWAS solution. Make sure correct image versions are specified in the `config.json` of the solution code.
+   * Yes. That's because image versions of [`twas-nd`](https://github.com/WASdev/azure.websphere-traditional.cluster/blob/main/src/main/bicep/config.json#L17) and [`ihs`](https://github.com/WASdev/azure.websphere-traditional.cluster/blob/main/src/main/bicep/config.json#L23) are explicitely referenced in the tWAS solution. Make sure correct image versions are specified in the `config.json` of the solution code.
 
 ## Updating and publishing the solution code
 
@@ -74,7 +74,7 @@ Note: **Wait for images to be published before proceeding with this step.** The 
 
 1. How to update the version of the solution?
    * Increase the [version number](https://github.com/WASdev/azure.websphere-traditional.cluster/blob/main/pom.xml#L23) which is specified in the `pom.xml`
-   * Also update the [`twasNdImageVersion`](https://github.com/WASdev/azure.websphere-traditional.cluster/blob/main/src/main/bicep/config.json#L18) and [`ihsImageVersion`](https://github.com/WASdev/azure.websphere-traditional.cluster/blob/main/src/main/bicep/config.json#L24) in the `config.json` (obtained from publish step)
+   * Also update the [`twasNdImageVersion`](https://github.com/WASdev/azure.websphere-traditional.cluster/blob/main/src/main/bicep/config.json#L17) and [`ihsImageVersion`](https://github.com/WASdev/azure.websphere-traditional.cluster/blob/main/src/main/bicep/config.json#L23) in the `config.json` (obtained from publish step)
    * Get the PR merged
 
 1. How to run CI/CD?

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
     <groupId>com.ibm.websphere.azure</groupId>
     <artifactId>azure.websphere-traditional.cluster</artifactId>
-    <version>1.4.0</version>
+    <version>1.4.1</version>
 
     <!-- mvn -Pbicep -Passembly clean install -Ptemplate-validation-tests -->
     <parent>

--- a/src/main/arm/createUiDefinition.json
+++ b/src/main/arm/createUiDefinition.json
@@ -411,6 +411,61 @@
                         "visible": "[bool(steps('IHSConfig').configIHS)]"
                     }
                 ]
+            },
+            {
+                "name": "NetworkingConfig",
+                "label": "Networking",
+                "subLabel": {
+                    "preValidation": "Provide required information for networking",
+                    "postValidation": "Done"
+                },
+                "bladeTitle": "Networking",
+                "elements": [
+                    {
+                        "name": "vnetInfo",
+                        "type": "Microsoft.Common.InfoBox",
+                        "options": {
+                            "icon": "Info",
+                            "text": "When creating a new virtual network, the subnet's address prefix is calculated automatically based on the virtual network's address prefix. When using an existing virtual network, a minimum virtual network size of /28 and a minimum subnet size of /29 are required. Additionally, the subnet must have adequate available addresses for the cluster setup."
+                        }
+                    },
+                    {
+                        "name": "vnetForCluster",
+                        "type": "Microsoft.Network.VirtualNetworkCombo",
+                        "label": {
+                            "virtualNetwork": "Virtual network",
+                            "subnets": "Subnets"
+                        },
+                        "toolTip": {
+                            "virtualNetwork": "Name of the virtual network",
+                            "subnets": "Subnets for the virtual network"
+                        },
+                        "defaultValue": {
+                            "name": "[concat('twascluster-vnet',take(guid(), 8))]",
+                            "addressPrefixSize": "/27"
+                        },
+                        "constraints": {
+                            "minAddressPrefixSize": "/28"
+                        },
+                        "options": {
+                            "hideExisting": false
+                        },
+                        "subnets": {
+                            "subnet1": {
+                                "label": "Subnet",
+                                "defaultValue": {
+                                    "name": "twas-cluster-subnet",
+                                    "addressPrefixSize": "/27"
+                                },
+                                "constraints": {
+                                    "minAddressPrefixSize": "/29",
+                                    "minAddressCount": "[add(int(steps('ClusterConfig').numberOfNodes), if(bool(steps('IHSConfig').configIHS), 2, 0))]",
+                                    "requireContiguousAddresses": false
+                                }
+                            }
+                        }
+                    }
+                ]
             }
         ],
         "outputs": {
@@ -436,7 +491,10 @@
             "ihsUnixPasswordOrKey": "[if(equals(steps('IHSConfig').ihsInfo.ihsUnixPasswordOrKey.authenticationType, 'password'), steps('IHSConfig').ihsInfo.ihsUnixPasswordOrKey.password, steps('IHSConfig').ihsInfo.ihsUnixPasswordOrKey.sshPublicKey)]",
             "ihsAuthenticationType": "[steps('IHSConfig').ihsInfo.ihsUnixPasswordOrKey.authenticationType]",
             "ihsAdminUsername": "[steps('IHSConfig').ihsInfo.ihsAdminUsername]",
-            "ihsAdminPassword": "[steps('IHSConfig').ihsInfo.ihsAdminPassword]"
+            "ihsAdminPassword": "[steps('IHSConfig').ihsInfo.ihsAdminPassword]",
+            "vnetForCluster": "[steps('NetworkingConfig').vnetForCluster]",
+            "newOrExistingVnetForCluster": "[steps('NetworkingConfig').vnetForCluster.newOrExisting]",
+            "vnetRGNameForCluster": "[steps('NetworkingConfig').vnetForCluster.resourceGroup]"
         }
     }
 }

--- a/src/main/bicep/config.json
+++ b/src/main/bicep/config.json
@@ -1,5 +1,4 @@
 {
-    "customerUsageAttributionId": "pid-fb16aee1-039d-45dc-a476-806224793a6c-partnercenter",
     "clusterStart": "c2efe274-0dc2-50f3-b51f-338a3fe01afb",
     "clusterEnd": "9c5dbfce-a6b9-5659-96bc-ca0cf429122a",
     "clusterTrialStart": "e71b564d-20cf-5fc6-a5f5-dc4857c8311b",

--- a/src/main/bicep/mainTemplate.bicep
+++ b/src/main/bicep/mainTemplate.bicep
@@ -154,7 +154,7 @@ var configBase64 = loadFileAsBase64('config.json')
 var config = base64ToJson(configBase64)
 
 module partnerCenterPid './modules/_pids/_empty.bicep' = {
-  name: config.customerUsageAttributionId
+  name: 'pid-fb16aee1-039d-45dc-a476-806224793a6c-partnercenter'
   params: {
   }
 }

--- a/src/main/bicep/mainTemplate.bicep
+++ b/src/main/bicep/mainTemplate.bicep
@@ -105,9 +105,31 @@ param ihsAdminUsername string = 'ihsadmin'
 @description('Password for IBM HTTP Server admin.')
 @secure()
 param ihsAdminPassword string = ''
+
+@description('VNET for cluster.')
+param vnetForCluster object = {
+  name: 'twascluster-vnet'
+  resourceGroup: resourceGroup().name
+  addressPrefixes: [
+    '10.0.0.32/27'
+  ]
+  addressPrefix: '10.0.0.32/27'
+  newOrExisting: 'new'
+  subnets: {
+    subnet1: {
+      name: 'twascluster-subnet'
+      addressPrefix: '10.0.0.32/27'
+      startAddress: '10.0.0.36'
+    }
+  }
+}
+@description('To mitigate ARM-TTK error: Control Named vnetForCluster must output the newOrExisting property when hideExisting is false')
+param newOrExistingVnetForCluster string = 'new'
+@description('To mitigate ARM-TTK error: Control Named vnetForCluster must output the resourceGroup property when hideExisting is false')
+param vnetRGNameForCluster string = resourceGroup().name
+
 param guidValue string = take(replace(newGuid(), '-', ''), 6)
 
-var const_addressPrefix = '10.0.0.0/16'
 var const_arguments = format(' {0} {1} {2} {3} {4} {5}', wasUsername, wasPassword, name_dmgrVM, numberOfNodes - 1, dynamic, configureIHS)
 var const_dnsLabelPrefix = format('{0}{1}', dnsLabelPrefix, guidValue)
 var const_ihsArguments1 = format(' {0} {1} {2} {3} {4}', name_dmgrVM, ihsUnixUsername, ihsAdminUsername, ihsAdminPassword, name_storageAccount)
@@ -137,9 +159,8 @@ var const_linuxConfiguration = {
 }
 var const_managedVMPrefix = format('{0}{1}VM', managedVMPrefix, guidValue)
 var const_mountPointPath = '/mnt/${name_share}'
+var const_newVNet = (newOrExistingVnetForCluster == 'new') ? true : false
 var const_scriptLocation = uri(_artifactsLocation, 'scripts/')
-var const_subnetAddressPrefix = '10.0.1.0/24'
-var const_subnetName = 'subnet01'
 var name_dmgrVM = format('{0}{1}VM', dmgrVMPrefix, guidValue)
 var name_ihsPublicIPAddress = '${name_ihsVM}-ip'
 var name_ihsVM = format('{0}{1}VM', ihsVMPrefix, guidValue)
@@ -147,7 +168,6 @@ var name_networkSecurityGroup = '${const_dnsLabelPrefix}-nsg'
 var name_publicIPAddress = '${name_dmgrVM}-ip'
 var name_share = 'wasshare'
 var name_storageAccount = 'storage${guidValue}'
-var name_virtualNetwork = '${const_dnsLabelPrefix}-vnet'
 
 // Work around arm-ttk test "Variables Must Be Referenced"
 var configBase64 = loadFileAsBase64('config.json')
@@ -171,7 +191,7 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2021-09-01' = {
   sku: {
     name: 'Standard_LRS'
   }
-  kind: 'Storage'
+  kind: 'StorageV2'
 }
 
 resource storageAccountFileSvc 'Microsoft.Storage/storageAccounts/fileServices@2021-09-01' = if (configureIHS) {
@@ -187,7 +207,7 @@ resource storageAccountFileShare 'Microsoft.Storage/storageAccounts/fileServices
   }
 }
 
-resource networkSecurityGroup 'Microsoft.Network/networkSecurityGroups@2021-08-01' = {
+resource networkSecurityGroup 'Microsoft.Network/networkSecurityGroups@2021-08-01' = if (const_newVNet) {
   name: name_networkSecurityGroup
   location: location
   properties: {
@@ -215,35 +235,38 @@ resource networkSecurityGroup 'Microsoft.Network/networkSecurityGroups@2021-08-0
   }
 }
 
-resource virtualNetwork 'Microsoft.Network/virtualNetworks@2021-08-01' = {
-  name: name_virtualNetwork
+resource virtualNetwork 'Microsoft.Network/virtualNetworks@2021-08-01' = if (const_newVNet) {
+  name: vnetForCluster.name
   location: location
   properties: {
     addressSpace: {
-      addressPrefixes: [
-        const_addressPrefix
-      ]
+      addressPrefixes: vnetForCluster.addressPrefixes
     }
-    enableDdosProtection: false
-    enableVmProtection: false
-  }
-  dependsOn: [
-    networkSecurityGroup
-  ]
-}
-
-resource subnet 'Microsoft.Network/virtualNetworks/subnets@2021-08-01' = {
-  parent: virtualNetwork
-  name: const_subnetName
-  properties: {
-    addressPrefix: const_subnetAddressPrefix
-    networkSecurityGroup: {
-      id: networkSecurityGroup.id
-    }
+    subnets: [
+      {
+        name: vnetForCluster.subnets.subnet1.name
+        properties: {
+          addressPrefix: vnetForCluster.subnets.subnet1.addressPrefix
+          networkSecurityGroup: {
+            id: networkSecurityGroup.id
+          }
+        }
+      }
+    ]
   }
 }
 
-resource publicIPAddress 'Microsoft.Network/publicIPAddresses@2021-08-01' = {
+resource existingVNet 'Microsoft.Network/virtualNetworks@2021-08-01' existing = if (!const_newVNet) {
+  name: vnetForCluster.name
+  scope: resourceGroup(vnetRGNameForCluster)
+}
+
+resource existingSubnet 'Microsoft.Network/virtualNetworks/subnets@2021-08-01' existing = if (!const_newVNet) {
+  parent: existingVNet
+  name: vnetForCluster.subnets.subnet1.name
+}
+
+resource publicIPAddress 'Microsoft.Network/publicIPAddresses@2021-08-01' = if (const_newVNet) {
   name: name_publicIPAddress
   location: location
   properties: {
@@ -254,7 +277,7 @@ resource publicIPAddress 'Microsoft.Network/publicIPAddresses@2021-08-01' = {
   }
 }
 
-resource dmgrVMNetworkInterface 'Microsoft.Network/networkInterfaces@2021-08-01' = {
+resource dmgrVMNetworkInterface 'Microsoft.Network/networkInterfaces@2021-08-01' = if (const_newVNet) {
   name: '${name_dmgrVM}-if'
   location: location
   properties: {
@@ -267,7 +290,7 @@ resource dmgrVMNetworkInterface 'Microsoft.Network/networkInterfaces@2021-08-01'
             id: publicIPAddress.id
           }
           subnet: {
-            id: subnet.id
+            id: resourceId('Microsoft.Network/virtualNetworks/subnets', vnetForCluster.name, vnetForCluster.subnets.subnet1.name)
           }
         }
       }
@@ -275,6 +298,27 @@ resource dmgrVMNetworkInterface 'Microsoft.Network/networkInterfaces@2021-08-01'
     dnsSettings: {
       internalDnsNameLabel: name_dmgrVM
     }
+  }
+  dependsOn: [
+    virtualNetwork
+  ]
+}
+
+resource dmgrVMNetworkInterfaceNoPubIp 'Microsoft.Network/networkInterfaces@2021-08-01' = if (!const_newVNet) {
+  name: '${name_dmgrVM}-no-pub-ip-if'
+  location: location
+  properties: {
+    ipConfigurations: [
+      {
+        name: 'ipconfig1'
+        properties: {
+          privateIPAllocationMethod: 'Dynamic'
+          subnet: {
+            id: existingSubnet.id
+          }
+        }
+      }
+    ]
   }
 }
 
@@ -288,7 +332,7 @@ resource managedVMNetworkInterfaces 'Microsoft.Network/networkInterfaces@2021-08
         properties: {
           privateIPAllocationMethod: 'Dynamic'
           subnet: {
-            id: subnet.id
+            id: const_newVNet ? resourceId('Microsoft.Network/virtualNetworks/subnets', vnetForCluster.name, vnetForCluster.subnets.subnet1.name) : existingSubnet.id
           }
         }
       }
@@ -297,6 +341,10 @@ resource managedVMNetworkInterfaces 'Microsoft.Network/networkInterfaces@2021-08
       internalDnsNameLabel: '${const_managedVMPrefix}${(i + 1)}'
     }
   }
+  dependsOn: [
+    virtualNetwork
+    existingSubnet
+  ]
 }]
 
 resource clusterVMs 'Microsoft.Compute/virtualMachines@2022-03-01' = [for i in range(0, numberOfNodes): {
@@ -331,7 +379,7 @@ resource clusterVMs 'Microsoft.Compute/virtualMachines@2022-03-01' = [for i in r
     networkProfile: {
       networkInterfaces: [
         {
-          id: resourceId('Microsoft.Network/networkInterfaces', format('{0}-if', i == 0 ? name_dmgrVM : '${const_managedVMPrefix}${i}'))
+          id: resourceId('Microsoft.Network/networkInterfaces', format('{0}-if', i == 0 ? (const_newVNet ? name_dmgrVM : '${name_dmgrVM}-no-pub-ip') : '${const_managedVMPrefix}${i}'))
         }
       ]
     }
@@ -405,7 +453,7 @@ module ihsStartPid './modules/_pids/_empty.bicep' = if (configureIHS) {
   }
 }
 
-resource ihsPublicIPAddress 'Microsoft.Network/publicIPAddresses@2021-08-01' = if (configureIHS) {
+resource ihsPublicIPAddress 'Microsoft.Network/publicIPAddresses@2021-08-01' = if (configureIHS && const_newVNet) {
   name: name_ihsPublicIPAddress
   location: location
   properties: {
@@ -416,7 +464,7 @@ resource ihsPublicIPAddress 'Microsoft.Network/publicIPAddresses@2021-08-01' = i
   }
 }
 
-resource ihsVMNetworkInterface 'Microsoft.Network/networkInterfaces@2021-08-01' = if (configureIHS) {
+resource ihsVMNetworkInterface 'Microsoft.Network/networkInterfaces@2021-08-01' = if (configureIHS && const_newVNet) {
   name: '${name_ihsVM}-if'
   location: location
   properties: {
@@ -429,7 +477,7 @@ resource ihsVMNetworkInterface 'Microsoft.Network/networkInterfaces@2021-08-01' 
             id: ihsPublicIPAddress.id
           }
           subnet: {
-            id: subnet.id
+            id: resourceId('Microsoft.Network/virtualNetworks/subnets', vnetForCluster.name, vnetForCluster.subnets.subnet1.name)
           }
         }
       }
@@ -437,6 +485,27 @@ resource ihsVMNetworkInterface 'Microsoft.Network/networkInterfaces@2021-08-01' 
     dnsSettings: {
       internalDnsNameLabel: name_ihsVM
     }
+  }
+  dependsOn: [
+    virtualNetwork
+  ]
+}
+
+resource ihsVMNetworkInterfaceNoPubIp 'Microsoft.Network/networkInterfaces@2021-08-01' = if (configureIHS && !const_newVNet) {
+  name: '${name_ihsVM}-no-pub-ip-if'
+  location: location
+  properties: {
+    ipConfigurations: [
+      {
+        name: 'ipconfig1'
+        properties: {
+          privateIPAllocationMethod: 'Dynamic'
+          subnet: {
+            id: existingSubnet.id
+          }
+        }
+      }
+    ]
   }
 }
 
@@ -472,7 +541,7 @@ resource ihsVM 'Microsoft.Compute/virtualMachines@2022-03-01' = if (configureIHS
     networkProfile: {
       networkInterfaces: [
         {
-          id: ihsVMNetworkInterface.id
+          id: const_newVNet ? ihsVMNetworkInterface.id : ihsVMNetworkInterfaceNoPubIp.id
         }
       ]
     }
@@ -538,7 +607,7 @@ output nodeGroupName string = 'DefaultNodeGroup'
 output coreGroupName string = 'DefaultCoreGroup'
 output dmgrHostName string = name_dmgrVM
 output dmgrPort string = '8879'
-output virtualNetworkName string = name_virtualNetwork
-output subnetName string = const_subnetName
-output adminSecuredConsole string = uri(format('https://{0}:9043/', publicIPAddress.properties.dnsSettings.fqdn), 'ibm/console')
-output ihsConsole string = configureIHS ? uri(format('http://{0}', ihsPublicIPAddress.properties.dnsSettings.fqdn), '') : 'N/A'
+output virtualNetworkName string = vnetForCluster.name
+output subnetName string = vnetForCluster.subnets.subnet1.name
+output adminSecuredConsole string = uri(format('https://{0}:9043/', const_newVNet ? publicIPAddress.properties.dnsSettings.fqdn : reference('${name_dmgrVM}-no-pub-ip-if').ipConfigurations[0].properties.privateIPAddress), 'ibm/console')
+output ihsConsole string = configureIHS ? uri(format('http://{0}', const_newVNet ? ihsPublicIPAddress.properties.dnsSettings.fqdn : reference('${name_ihsVM}-no-pub-ip-if').ipConfigurations[0].properties.privateIPAddress), '') : 'N/A'

--- a/src/main/bicep/mainTemplate.bicep
+++ b/src/main/bicep/mainTemplate.bicep
@@ -169,6 +169,7 @@ var name_publicIPAddress = '${name_dmgrVM}-ip'
 var name_share = 'wasshare'
 var name_storageAccount = 'storage${guidValue}'
 var name_storageAccountPrivateEndpoint = 'storagepe${guidValue}'
+var ref_storageAccountPrivateEndpoint = configureIHS ? reference(name_storageAccountPrivateEndpoint, '2021-05-01').customDnsConfigs[0].ipAddresses[0] : ''
 
 // Work around arm-ttk test "Variables Must Be Referenced"
 var configBase64 = loadFileAsBase64('config.json')
@@ -457,7 +458,7 @@ resource clusterVMsExtension 'Microsoft.Compute/virtualMachines/extensions@2022-
       ]
     }
     protectedSettings: {
-      commandToExecute: format('sh install.sh {0}{1}{2}', i == 0, const_arguments, configureIHS ? format(' {0} {1}{2} {3}', name_storageAccount, listKeys(storageAccount.id, '2021-09-01').keys[0].value, const_ihsArguments2, reference(name_storageAccountPrivateEndpoint, '2021-05-01').customDnsConfigs[0].ipAddresses[0]) : '')
+      commandToExecute: format('sh install.sh {0}{1}{2}', i == 0, const_arguments, configureIHS ? format(' {0} {1}{2} {3}', name_storageAccount, listKeys(storageAccount.id, '2021-09-01').keys[0].value, const_ihsArguments2, ref_storageAccountPrivateEndpoint) : '')
     }
   }
   dependsOn: [
@@ -611,7 +612,7 @@ resource ihsVMExtension 'Microsoft.Compute/virtualMachines/extensions@2022-03-01
       ]
     }
     protectedSettings: {
-      commandToExecute: format('sh configure-ihs.sh{0} {1}{2} {3}', const_ihsArguments1, listKeys(storageAccount.id, '2021-09-01').keys[0].value, const_ihsArguments2, reference(name_storageAccountPrivateEndpoint, '2021-05-01').customDnsConfigs[0].ipAddresses[0])
+      commandToExecute: format('sh configure-ihs.sh{0} {1}{2} {3}', const_ihsArguments1, listKeys(storageAccount.id, '2021-09-01').keys[0].value, const_ihsArguments2, ref_storageAccountPrivateEndpoint)
     }
   }
   dependsOn: [

--- a/src/main/bicep/modules/_pids/_empty.bicep
+++ b/src/main/bicep/modules/_pids/_empty.bicep
@@ -13,3 +13,8 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 */
+
+// Workaround to arm-ttk complain: Parameters property must exist in the template
+param name string = 'This is an empty deployment'
+
+output name string = name

--- a/src/main/scripts/configure-ihs-on-dmgr.sh
+++ b/src/main/scripts/configure-ihs-on-dmgr.sh
@@ -15,9 +15,9 @@
 #  limitations under the License.
 
 # Check required parameters
-if [ "$7" == "" ]; then 
+if [ "$8" == "" ]; then 
   echo "Usage:"
-  echo "  ./configure-ihs-on-dmgr.sh [profile] [wasUser] [wasPassword] [storageAccountName] [storageAccountKey] [fileShareName] [mountpointPath]"
+  echo "  ./configure-ihs-on-dmgr.sh [profile] [wasUser] [wasPassword] [storageAccountName] [storageAccountKey] [fileShareName] [mountpointPath] [storageAccountPrivateIp]"
   exit 1
 fi
 profile=$1
@@ -27,6 +27,7 @@ storageAccountName=$4
 storageAccountKey=$5
 fileShareName=$6
 mountpointPath=$7
+storageAccountPrivateIp=$8
 
 echo "$(date): Start to configure IHS on dmgr."
 
@@ -38,11 +39,11 @@ mkdir /etc/smbcredentials
 echo "username=$storageAccountName" > /etc/smbcredentials/${storageAccountName}.cred
 echo "password=$storageAccountKey" >> /etc/smbcredentials/${storageAccountName}.cred
 chmod 600 /etc/smbcredentials/${storageAccountName}.cred
-echo "//${storageAccountName}.file.core.windows.net/${fileShareName} $mountpointPath cifs nofail,credentials=/etc/smbcredentials/${storageAccountName}.cred,dir_mode=0777,file_mode=0777,serverino" >> /etc/fstab
+echo "//${storageAccountPrivateIp}/${fileShareName} $mountpointPath cifs nofail,credentials=/etc/smbcredentials/${storageAccountName}.cred,dir_mode=0777,file_mode=0777,serverino" >> /etc/fstab
 
-mount -t cifs //${storageAccountName}.file.core.windows.net/${fileShareName} $mountpointPath -o credentials=/etc/smbcredentials/${storageAccountName}.cred,dir_mode=0777,file_mode=0777,serverino
+mount -t cifs //${storageAccountPrivateIp}/${fileShareName} $mountpointPath -o credentials=/etc/smbcredentials/${storageAccountName}.cred,dir_mode=0777,file_mode=0777,serverino
 if [[ $? != 0 ]]; then
-  echo "$(date): Failed to mount //${storageAccountName}.file.core.windows.net/${fileShareName} $mountpointPath."
+  echo "$(date): Failed to mount //${storageAccountPrivateIp}/${fileShareName} $mountpointPath."
   exit 1
 fi
 

--- a/src/main/scripts/configure-ihs.sh
+++ b/src/main/scripts/configure-ihs.sh
@@ -74,9 +74,9 @@ if [ ${result} != $ENTITLED ] && [ ${result} != $EVALUATION ]; then
 fi
 
 # Check required parameters
-if [ "$8" == "" ]; then 
+if [ "$9" == "" ]; then 
   echo "Usage:"
-  echo "  ./configure-ihs.sh [dmgrHostname] [ihsUnixUsername] [ihsAdminUsername] [ihsAdminPassword] [storageAccountName] [storageAccountKey] [fileShareName] [mountpointPath]"
+  echo "  ./configure-ihs.sh [dmgrHostname] [ihsUnixUsername] [ihsAdminUsername] [ihsAdminPassword] [storageAccountName] [storageAccountKey] [fileShareName] [mountpointPath] [storageAccountPrivateIp]"
   exit 1
 fi
 dmgrHostname=$1
@@ -87,6 +87,7 @@ storageAccountName=$5
 storageAccountKey=$6
 fileShareName=$7
 mountpointPath=$8
+storageAccountPrivateIp=$9
 
 echo "$(date): Start to configure IHS."
 
@@ -136,11 +137,11 @@ mkdir /etc/smbcredentials
 echo "username=$storageAccountName" > /etc/smbcredentials/${storageAccountName}.cred
 echo "password=$storageAccountKey" >> /etc/smbcredentials/${storageAccountName}.cred
 chmod 600 /etc/smbcredentials/${storageAccountName}.cred
-echo "//${storageAccountName}.file.core.windows.net/${fileShareName} $mountpointPath cifs nofail,credentials=/etc/smbcredentials/${storageAccountName}.cred,dir_mode=0777,file_mode=0777,serverino" >> /etc/fstab
+echo "//${storageAccountPrivateIp}/${fileShareName} $mountpointPath cifs nofail,credentials=/etc/smbcredentials/${storageAccountName}.cred,dir_mode=0777,file_mode=0777,serverino" >> /etc/fstab
 
-mount -t cifs //${storageAccountName}.file.core.windows.net/${fileShareName} $mountpointPath -o credentials=/etc/smbcredentials/${storageAccountName}.cred,dir_mode=0777,file_mode=0777,serverino
+mount -t cifs //${storageAccountPrivateIp}/${fileShareName} $mountpointPath -o credentials=/etc/smbcredentials/${storageAccountName}.cred,dir_mode=0777,file_mode=0777,serverino
 if [[ $? != 0 ]]; then
-  echo "$(date): Failed to mount //${storageAccountName}.file.core.windows.net/${fileShareName} $mountpointPath."
+  echo "$(date): Failed to mount //${storageAccountPrivateIp}/${fileShareName} $mountpointPath."
   exit 1
 fi
 

--- a/src/main/scripts/install.sh
+++ b/src/main/scripts/install.sh
@@ -249,9 +249,9 @@ if [ ${result} != $ENTITLED ] && [ ${result} != $EVALUATION ]; then
 fi
 
 # Check required parameters
-if [ "$7" = True ] && [ "${11}" == "" ]; then 
+if [ "$7" = True ] && [ "${12}" == "" ]; then 
   echo "Usage:"
-  echo "  ./install.sh [dmgr] [adminUserName] [adminPassword] [dmgrHostName] [members] [dynamic] True [storageAccountName] [storageAccountKey] [fileShareName] [mountpointPath]"
+  echo "  ./install.sh [dmgr] [adminUserName] [adminPassword] [dmgrHostName] [members] [dynamic] True [storageAccountName] [storageAccountKey] [fileShareName] [mountpointPath] [storageAccountPrivateIp]"
   exit 1
 elif [ "$7" == "" ]; then 
   echo "Usage:"
@@ -269,6 +269,7 @@ storageAccountName=$8
 storageAccountKey=$9
 fileShareName=${10}
 mountpointPath=${11}
+storageAccountPrivateIp=${12}
 
 # Create cluster by creating deployment manager, node agent & add nodes to be managed
 if [ "$dmgr" = True ]; then
@@ -280,7 +281,7 @@ if [ "$dmgr" = True ]; then
 
     # Configure IHS if required
     if [ "$configureIHS" = True ]; then
-        ./configure-ihs-on-dmgr.sh Dmgr001 "$adminUserName" "$adminPassword" "$storageAccountName" "$storageAccountKey" "$fileShareName" "$mountpointPath"
+        ./configure-ihs-on-dmgr.sh Dmgr001 "$adminUserName" "$adminPassword" "$storageAccountName" "$storageAccountKey" "$fileShareName" "$mountpointPath" "$storageAccountPrivateIp"
     fi
 else
     create_custom_profile Custom $(hostname) $(hostname)Node01 $dmgrHostName 8879 "$adminUserName" "$adminPassword"


### PR DESCRIPTION
## Description

The PR is to resolve the following issues:
* Resolve #167

## Change summary

* Add `Microsoft.Network.VirtualNetworkCombo` to `createUiDefinition.json` so user can create a new VNet or select an existing VNet;
* Update `mainTemplate.bicep` to support creating a new VNet or use the existing VNet per user input
   * For the case of using the existing VNet, no public IP address created and assigned to network interface
   * Create a private endpoint as a communication channel between the storage account and cluster if ihs is enabled

## Testing

The following test cases have already been passed before opening the PR:

* Successfully deployed a twas-nd cluster and an IHS with a new VNet on an Azure VM with evaluation license using the preview link below.
* Successfully deployed a twas-nd cluster and an IHS with an existing VNet on an Azure VM with evaluation license using the preview link below.
* Successfully deployed a twas-nd cluster with a new VNet on an Azure VM with evaluation license using the preview link below.
* Successfully deployed a twas-nd cluster with an existing VNet on an Azure VM with evaluation license using the preview link below.

Here is the [preview link](https://portal.azure.com/?feature.customportal=false#create/microsoft_javaeeonazure_test.20191212-arm-rhel-was-nd-v9-cluster-previewwasndt91-n-cluster) for live testing.

## UI changes review

Besides visiting [preview link](https://portal.azure.com/?feature.customportal=false#create/microsoft_javaeeonazure_test.20191212-arm-rhel-was-nd-v9-cluster-previewwasndt91-n-cluster) for reviewing new blade `Networking`, reviewer can preview the UI changes using the **Create UI Definition Sandbox**:

- Open [Create UI Definition Sandbox](https://portal.azure.com/?feature.customPortal=false#blade/Microsoft_Azure_CreateUIDef/SandboxBlade) in a new tab of browser.
- Open UI source code [createUiDefinition.json](https://raw.githubusercontent.com/majguo/azure.websphere-traditional.cluster/bring-your-own-vnet/src/main/arm/createUiDefinition.json) in a new tab of the browser.
- Replace the content of work area in **Create UI Definition Sandbox** with the content of **UI source code `createUiDefinition.json`**.
- Click **Preview** at the left-bottom of **Create UI Definition Sandbox**.
- Switch to `Networking` tab > Start UI content review.
   - Label of new blade `Networking`
   - Information box: `When creating a new virtual network, the subnet's address prefix is calculated automatically based on the virtual network's address prefix. When using an existing virtual network, a minimum virtual network size of /28 and a minimum subnet size of /29 are required. Additionally, the subnet must have adequate available addresses for the cluster setup.`
   - **Configure virtual networks** is a standard component from Azure Portal, only the following text can be customized:
      - Label `Virtual network` and its tooltip `Name of the virtual network`
      - Label `Subnet` and its tooltip `Subnets for the virtual network`

Here is the screenshot of user experience design, see new blade **Networking** within the red-line box:
![image](https://user-images.githubusercontent.com/10357495/179436950-0b23c9c1-0965-4cb7-b183-3bbd22abb871.png)
Signed-off-by: Jianguo Ma <jiangma@microsoft.com>