### PR TITLE
Agree to IBM contacting customer's company or organization

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
     <groupId>com.ibm.websphere.azure</groupId>
     <artifactId>azure.websphere-traditional.cluster</artifactId>
-    <version>1.4.2</version>
+    <version>1.3.35</version>
 
     <!-- mvn -Pbicep -Passembly clean install -Ptemplate-validation-tests -->
     <parent>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
     <groupId>com.ibm.websphere.azure</groupId>
     <artifactId>azure.websphere-traditional.cluster</artifactId>
-    <version>1.4.1</version>
+    <version>1.4.2</version>
 
     <!-- mvn -Pbicep -Passembly clean install -Ptemplate-validation-tests -->
     <parent>

--- a/src/main/arm/createUiDefinition.json
+++ b/src/main/arm/createUiDefinition.json
@@ -88,7 +88,7 @@
                 "name": "shareCompanyNameCheck",
                 "type": "Microsoft.Common.CheckBox",
                 "label": "I agree to IBM contacting my company or organization.",
-                "toolTip": "Select to agree to IBM contacting my company or organization.",
+                "toolTip": "Select to agree to IBM contacting your company or organization.",
                 "constraints": {
                     "required": false
                 },

--- a/src/main/arm/createUiDefinition.json
+++ b/src/main/arm/createUiDefinition.json
@@ -76,6 +76,25 @@
                 }
             },
             {
+                "name": "shareCompanyNameInfo",
+                "type": "Microsoft.Common.InfoBox",
+                "options": {
+                    "icon": "Info",
+                    "text": "Check the following box if you agree to share your company's or organization's contact information with IBM for the purpose of discussing IBM offerings."
+                },
+                "visible": "[bool(basics('useTrial'))]"
+            },
+            {
+                "name": "shareCompanyNameCheck",
+                "type": "Microsoft.Common.CheckBox",
+                "label": "I agree to IBM contacting my company or organization.",
+                "toolTip": "Select to agree to IBM contacting my company or organization.",
+                "constraints": {
+                    "required": false
+                },
+                "visible": "[bool(basics('useTrial'))]"
+            },
+            {
                 "name": "howToReportIssues",
                 "type": "Microsoft.Common.Section",
                 "label": "Report issues, get help, and share feedback",
@@ -473,6 +492,7 @@
             "useTrial": "[bool(basics('useTrial'))]",
             "ibmUserId": "[basics('ibmUserId')]",
             "ibmUserPwd": "[basics('ibmUserPwd')]",
+            "shareCompanyName": "[bool(basics('shareCompanyNameCheck'))]",
             "numberOfNodes": "[int(steps('ClusterConfig').numberOfNodes)]",
             "vmSize": "[steps('ClusterConfig').vmSizeSelect]",
             "dmgrVMPrefix": "[steps('ClusterConfig').dmgrVMPrefix]",

--- a/src/main/bicep/config.json
+++ b/src/main/bicep/config.json
@@ -20,5 +20,6 @@
     "ihsImageSkuDescription": "This is the ihs 'Plan ID' of the plan within the 'Azure Virtual Machine' offer",
     "ihsImageSku": "2021-06-03-ihs-base-image",
     "ihsImageVersionDescription": "This is the ihs 'Disk version' of the VM image of the plan within the 'Azure Virtual Machine' offer",
-    "ihsImageVersion": "9.0.20220621"
+    "ihsImageVersion": "9.0.20220621",
+    "shareCompanyNamePid": "f246c770-92c5-5a97-b5d6-83feac7623d3"
 }

--- a/src/main/bicep/mainTemplate.bicep
+++ b/src/main/bicep/mainTemplate.bicep
@@ -34,6 +34,9 @@ param ibmUserId string = ''
 @secure()
 param ibmUserPwd string = ''
 
+@description('Boolean value indicating, if user agrees to IBM contacting my company or organization.')
+param shareCompanyName bool = false
+
 @description('Boolean value indicating, if the cluster is a dynamic one or not.')
 param dynamic bool = false
 
@@ -179,6 +182,11 @@ module partnerCenterPid './modules/_pids/_empty.bicep' = {
   name: 'pid-fb16aee1-039d-45dc-a476-806224793a6c-partnercenter'
   params: {
   }
+}
+
+module shareCompanyNamePid './modules/_pids/_empty.bicep' = if (useTrial && shareCompanyName) {
+  name: config.shareCompanyNamePid
+  params: {}
 }
 
 module clusterStartPid './modules/_pids/_empty.bicep' = {


### PR DESCRIPTION
The PR is to add a checkbox which asks user if he/she agrees to IBM contacting his/her company or organization when deploying with an evaluation license:
* Add information box and check box in the UI to check user's agreement
* Deploy an Azure deployment with a pre-defined unique name if user agrees

See details from the relevant issue: WASdev/azure.websphere-traditional.cluster/issues/159.

## Screenshot of UI changes

1. Info box + checkbox:   
   ![image](https://user-images.githubusercontent.com/10357495/181493620-4c0e316a-c12b-425b-a921-63b2853c9346.png)

1. Info box + checkbox + tooltip of checkbox:
    ![image](https://user-images.githubusercontent.com/10357495/181493716-91057327-84a3-43e0-b093-77224d90c931.png)
 
## Testing

The following test cases have already been passed before opening the PR:

* Deployed a twas-nd cluster and an IHS with evaluation license **with** user's agreement for contacting: the dedicated deployment is created.
* Deployed a twas-nd cluster and an IHS with evaluation license **without** user's agreement for contacting: the dedicated deployment is not created.
* Deployed a twas-nd cluster and an IHS with an invalid IBMid: the dedicated deployment is not created.

Here is the [preview link](https://portal.azure.com/?feature.customportal=false#create/microsoft_javaeeonazure_test.20191212-arm-rhel-was-nd-v9-cluster-previewwasndt91-n-cluster) for live testing.

Signed-off-by: Jianguo Ma <jiangma@microsoft.com>