### PR TITLE
Add integration test pipeline and fix deployment hang after upgrade to 9.0.5.13

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -1,0 +1,136 @@
+name: integration-test
+on:
+  workflow_dispatch:
+  # Allows you to run this workflow using GitHub APIs
+  # PERSONAL_ACCESS_TOKEN=<GITHUB_PERSONAL_ACCESS_TOKEN>
+  # REPO_NAME=WASdev/azure.websphere-traditional.cluster
+  # curl --verbose -XPOST -u "WASdev:${PERSONAL_ACCESS_TOKEN}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" https://api.github.com/repos/${REPO_NAME}/actions/workflows/integration-test.yaml/dispatches --data '{"ref": "main"}'
+  repository_dispatch:
+    types: [integration-test]
+  # sample request
+  # PERSONAL_ACCESS_TOKEN=<GITHUB_PERSONAL_ACCESS_TOKEN>
+  # REPO_NAME=WASdev/azure.websphere-traditional.cluster
+  # curl --verbose -X POST https://api.github.com/repos/${REPO_NAME}/dispatches -H "Accept: application/vnd.github.everest-preview+json" -H "Authorization: token ${PERSONAL_ACCESS_TOKEN}" --data '{"event_type": "integration-test"}'
+env:
+  # Latest version is at https://github.com/Azure/azure-cli/releases
+  azCliVersion: 2.31.0
+  # Commit hash from https://github.com/Azure/arm-ttk/commits/master
+  refArmttk: cf5c927eaf1f5652556e86a6b67816fc910d1b74
+  # Commit hash from https://github.com/Azure/azure-javaee-iaas/commits/main
+  refJavaee: f25ab89a2a8848da39b84e5d6c927f4c4cb47200
+  bicepVersion: v0.7.4
+  repoName: "azure.websphere-traditional.cluster"
+  azureCredentials: ${{ secrets.AZURE_CREDENTIALS }}
+  userName: ${{ secrets.USER_NAME }}
+  msTeamsWebhook: ${{ secrets.MSTEAMS_WEBHOOK }}
+  vmAdminId: ${{ secrets.VM_ADMIN_ID }}
+  vmAdminPassword: ${{ secrets.VM_ADMIN_PASSWORD }}
+  testResourceGroup: twasClusterTestRG${{ github.run_id }}${{ github.run_number }}
+  testDeploymentName: twasClusterTestDeployment${{ github.run_id }}${{ github.run_number }}
+  location: eastus
+jobs:
+  integration-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: Set up bicep
+        run: |
+          curl -Lo bicep https://github.com/Azure/bicep/releases/download/${{ env.bicepVersion }}/bicep-linux-x64
+          chmod +x ./bicep
+          sudo mv ./bicep /usr/local/bin/bicep
+          bicep --version
+      - name: Checkout azure-javaee-iaas
+        uses: actions/checkout@v2
+        with:
+          repository: Azure/azure-javaee-iaas
+          path: azure-javaee-iaas
+          ref: ${{ env.refJavaee }}
+      - name: Checkout arm-ttk
+        uses: actions/checkout@v2
+        with:
+          repository: Azure/arm-ttk
+          path: arm-ttk
+          ref: ${{ env.refArmttk }}
+      - name: Checkout ${{ env.repoName }}
+        uses: actions/checkout@v2
+        with:
+          path: ${{ env.repoName }}
+          ref: ${{ github.event.inputs.ref }}
+      - name: Build azure-javaee-iaas
+        run: mvn -DskipTests clean install --file azure-javaee-iaas/pom.xml
+      - name: Build ${{ env.repoName }}
+        run: |
+          cd ${{ env.repoName }}
+          mvn -Dgit.repo=${{ env.userName }} -Dgit.tag=$GITHUB_REF_NAME -DuseTrial=true \
+            -DnumberOfNodes=2 -DvmSize=Standard_D2_v3 -DdmgrVMPrefix=dmgr -DmanagedVMPrefix=managed -DdnsLabelPrefix=wasndcluster \
+            -DadminUsername=${{ env.vmAdminId }} -DadminPasswordOrKey=${{ env.vmAdminPassword }} \
+            -DauthenticationType=password -DwasUsername=${{ env.vmAdminId }} -DwasPassword=${{ env.vmAdminPassword }} \
+            -DconfigureIHS=true -DihsVmSize=Standard_D2_v3 -DihsVMPrefix=ihs -DihsDnsLabelPrefix=ihs \
+            -DihsUnixUsername=${{ env.vmAdminId }} -DihsUnixPasswordOrKey=${{ env.vmAdminPassword }} \
+            -DihsAuthenticationType=password -DihsAdminUsername=${{ env.vmAdminId }} -DihsAdminPassword=${{ env.vmAdminPassword }} \
+            -Dtest.args="-Test All" -Pbicep -Passembly -Ptemplate-validation-tests clean install
+      - uses: azure/login@v1
+        id: azure-login
+        with:
+          creds: ${{ env.azureCredentials }}
+      - name: Deploy a twas-cluster servers on Azure VMs
+        run: |
+          cd ${{ env.repoName }}/target/cli
+          chmod a+x deploy.azcli
+          ./deploy.azcli -n ${{ env.testDeploymentName }} -g ${{ env.testResourceGroup }} -l ${{ env.location }}
+      - name: Verify the deployment
+        run: |
+          outputs=$(az deployment group show -n ${{ env.testDeploymentName }} -g ${{ env.testResourceGroup }} --query 'properties.outputs')
+          adminSecuredConsole=$(echo $outputs | jq -r '.adminSecuredConsole.value')
+          curl $adminSecuredConsole -k
+          if [[ $? -ne 0 ]]; then
+            echo "Failed to access ${adminSecuredConsole}."
+            exit 1
+          fi
+          ihsConsole=$(echo $outputs | jq -r '.ihsConsole.value')
+          curl $ihsConsole
+          if [[ $? -ne 0 ]]; then
+            echo "Failed to access ${ihsConsole}."
+            exit 1
+          fi
+      - name: Generate artifact file name and path
+        id: artifact_file
+        run: |
+          version=$(awk '/<version>[^<]+<\/version>/{gsub(/<version>|<\/version>/,"",$1);print $1;exit;}' ${{ env.repoName }}/pom.xml)
+          artifactName=${{ env.repoName }}-$version-arm-assembly
+          unzip ${{ env.repoName }}/target/$artifactName.zip -d ${{ env.repoName }}/target/$artifactName
+          echo "##[set-output name=artifactName;]${artifactName}"
+          echo "##[set-output name=artifactPath;]${{ env.repoName }}/target/$artifactName"
+      - name: Archive ${{ env.repoName }} template
+        uses: actions/upload-artifact@v1
+        if: success()
+        with:
+          name: ${{steps.artifact_file.outputs.artifactName}}
+          path: ${{steps.artifact_file.outputs.artifactPath}}
+  notification:
+    needs: integration-test
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send notification
+        if: always()
+        run: |
+            workflowJobs=$(curl -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/${{ env.userName }}/${{ env.repoName }}/actions/runs/${{ github.run_id }}/jobs)
+            successIntegrationTestJob=$(echo $workflowJobs | jq '.jobs | map(select(.name=="integration-test" and .conclusion=="success")) | length')
+            if (($successIntegrationTestJob == 0));then
+                echo "Job integration-test failed, send notification to Teams"
+                curl ${{ env.msTeamsWebhook }} \
+                -H 'Content-Type: application/json' \
+                --data-binary @- << EOF
+                {
+                "@context":"http://schema.org/extensions",
+                "@type":"MessageCard",
+                "text":"Workflow integration-test of repo ${{ env.repoName }} failed, please take a look at: https://github.com/${{ env.userName }}/${{ env.repoName }}/actions/runs/${{ github.run_id }}"
+                }
+            EOF
+            else
+                echo "Job integration-test succeeded."
+            fi

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -76,7 +76,7 @@ jobs:
         id: azure-login
         with:
           creds: ${{ env.azureCredentials }}
-      - name: Deploy a twas-cluster servers on Azure VMs
+      - name: Deploy a twas-cluster on Azure VMs
         run: |
           cd ${{ env.repoName }}/target/cli
           chmod a+x deploy.azcli
@@ -96,6 +96,14 @@ jobs:
             echo "Failed to access ${ihsConsole}."
             exit 1
           fi
+      - name: Delete all Azure resources
+        id: delete-resources-in-group
+        if: always()
+        uses: azure/CLI@v1
+        with:
+          azcliversion: ${{ env.azCliVersion }}
+          inlineScript: |
+            az group delete -n ${{ env.testResourceGroup }} --yes
       - name: Generate artifact file name and path
         id: artifact_file
         run: |

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@
 1. Using `deploy.azcli` to deploy
 
    ```bash
-   ./deploy.azcli -n <deploymentName> -i <subscriptionId> -g <resourceGroupName> -l <resourceGroupLocation>
+   ./deploy.azcli -n <deploymentName> -g <resourceGroupName> -l <resourceGroupLocation>
    ```
 
 ## After deployment

--- a/docs/howto-update-for-was-fixpack.md
+++ b/docs/howto-update-for-was-fixpack.md
@@ -78,10 +78,10 @@ Note: **Wait for images to be published before proceeding with this step.** The 
    * Get the PR merged
 
 1. How to run CI/CD?
-   * Go to [Actions](https://github.com/WASdev/azure.websphere-traditional.cluster/actions) > Click `Package ARM` > Click to expand `Run workflow` > Click `Run workflow` > Refresh the page
+   * Go to [Actions](https://github.com/WASdev/azure.websphere-traditional.cluster/actions) > Click `integration-test` > Click to expand `Run workflow` > Click `Run workflow` > Refresh the page
 
 1. How to publish the solution in marketplace and who can do it? (**Note: Make sure the images are published before publishing the solution**)
-   1. Wait until the CI/CD workflow for `Package ARM` successfully completes 
+   1. Wait until the CI/CD workflow for `integration-test` successfully completes 
        * Click to open details of the workflow run > Scroll to the bottom of the page
        * Click `azure.websphere-traditional.cluster-<version>-arm-assembly` to download the zip file `azure.websphere-traditional.cluster-<version>-arm-assembly.zip`;
    3. Sign into [Microsoft Partner Center](https://partner.microsoft.com/dashboard/commercial-marketplace/overview)
@@ -93,7 +93,7 @@ Note: **Wait for images to be published before proceeding with this step.** The 
        * Scroll to the bottom of the page
        * Click `Save draft`
        * Click `Review and publish`
-       * In the "Notes for certification" section enter the `Package ARM` URL
+       * In the "Notes for certification" section enter the `integration-test` URL
        * Click `Publish`
        * Wait until solution offer is in `Publisher signoff` (aka "preview") stage and "Go Live" button appears(it could take few hours)
        * Before clicking "Go Live" use the preview link to test the solution

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
     <groupId>com.ibm.websphere.azure</groupId>
     <artifactId>azure.websphere-traditional.cluster</artifactId>
-    <version>1.3.36</version>
+    <version>1.3.37</version>
 
     <!-- mvn -Pbicep -Passembly clean install -Ptemplate-validation-tests -->
     <parent>

--- a/src/main/bicep/mainTemplate.bicep
+++ b/src/main/bicep/mainTemplate.bicep
@@ -646,5 +646,5 @@ output dmgrHostName string = name_dmgrVM
 output dmgrPort string = '8879'
 output virtualNetworkName string = vnetForCluster.name
 output subnetName string = vnetForCluster.subnets.subnet1.name
-output adminSecuredConsole string = uri(format('https://{0}:9043/', const_newVNet ? publicIPAddress.properties.dnsSettings.fqdn : reference('${name_dmgrVM}-no-pub-ip-if').ipConfigurations[0].properties.privateIPAddress), 'ibm/console')
+output adminSecuredConsole string = uri(format('https://{0}:9043/', const_newVNet ? publicIPAddress.properties.dnsSettings.fqdn : reference('${name_dmgrVM}-no-pub-ip-if').ipConfigurations[0].properties.privateIPAddress), 'ibm/console/logon.jsp')
 output ihsConsole string = configureIHS ? uri(format('http://{0}', const_newVNet ? ihsPublicIPAddress.properties.dnsSettings.fqdn : reference('${name_ihsVM}-no-pub-ip-if').ipConfigurations[0].properties.privateIPAddress), '') : 'N/A'

--- a/src/main/cli/deploy.azcli
+++ b/src/main/cli/deploy.azcli
@@ -21,10 +21,9 @@ IFS=$'\n\t'
 # -o: prevents errors in a pipeline from being masked
 # IFS new value is less likely to cause confusing bugs when looping arrays or arguments (e.g. $@)
 
-usage() { echo "Usage: $0 -n <deploymentName> -i <subscriptionId> -g <resourceGroupName> -l <resourceGroupLocation>" 1>&2; exit 1; }
+usage() { echo "Usage: $0 -n <deploymentName> -g <resourceGroupName> -l <resourceGroupLocation>" 1>&2; exit 1; }
 
 declare deploymentName=""
-declare subscriptionId=""
 declare resourceGroupName=""
 declare resourceGroupLocation=""
 
@@ -33,9 +32,6 @@ while getopts ":n:i:g:l:" arg; do
 	case "${arg}" in
 		n)
 			deploymentName=${OPTARG}
-			;;
-		i)
-			subscriptionId=${OPTARG}
 			;;
 		g)
 			resourceGroupName=${OPTARG}
@@ -51,13 +47,6 @@ shift $((OPTIND-1))
 if [[ -z "$deploymentName" ]]; then
 	echo "Enter a name for this deployment:"
 	read deploymentName
-fi
-
-if [[ -z "$subscriptionId" ]]; then
-	echo "Your subscription ID can be looked up with the CLI using: az account show --out json "
-	echo "Enter your subscription ID:"
-	read subscriptionId
-	[[ "${subscriptionId:?}" ]]
 fi
 
 if [[ -z "$resourceGroupName" ]]; then
@@ -76,8 +65,8 @@ if [[ -z "$resourceGroupLocation" ]]; then
 	read resourceGroupLocation
 fi
 
-if [ -z "$deploymentName" ] || [ -z "$subscriptionId" ] || [ -z "$resourceGroupName" ]; then
-	echo "Either one of deploymentName, subscriptionId and resourceGroupName is empty"
+if [ -z "$deploymentName" ] || [ -z "$resourceGroupName" ]; then
+	echo "Either one of deploymentName and resourceGroupName is empty"
 	usage
 fi
 
@@ -103,9 +92,6 @@ az account show 1> /dev/null
 if [ $? != 0 ]; then
 	az login
 fi
-
-#set the default subscription id
-az account set --subscription $subscriptionId
 
 set +e
 

--- a/src/main/scripts/install.sh
+++ b/src/main/scripts/install.sh
@@ -190,11 +190,13 @@ create_custom_profile() {
     
     echo "$(date): Check if dmgr is ready."
     curl $dmgrHostName:$dmgrPort --output - >/dev/null 2>&1
-    while [ $? -ne 56 ]
+    rtnCode=$?
+    while [ $rtnCode -ne 0 ] && [ $rtnCode -ne 56 ]
     do
         sleep 5
         echo "dmgr is not ready"
         curl $dmgrHostName:$dmgrPort --output - >/dev/null 2>&1
+        rtnCode=$?
     done
     sleep 60
     echo "$(date): Dmgr is ready, start to create custom profile."


### PR DESCRIPTION
The PR is to resolve the following issues by adding a new integration testing pipeline and fixing the deployment hang after upgrading to 9.0.5.13:
* Resolve #171 
* Resolve #174 

See the successful rans of pipeline:
* [integration-test · majguo/azure.websphere-traditional.cluster@31650ca (github.com)](https://github.com/majguo/azure.websphere-traditional.cluster/actions/runs/2990028821)
* [integration-test · majguo/azure.websphere-traditional.cluster@8b3a6d1 (github.com)](https://github.com/majguo/azure.websphere-traditional.cluster/actions/runs/2975966243)

Signed-off-by: Jianguo Ma <jiangma@microsoft.com>