### PR TITLE
Upgrade versions of external deps used in pipelines by referencing to the centralized config file

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -43,7 +43,7 @@ env:
   # Latest version is at https://github.com/Azure/azure-cli/releases
   azCliVersion: 2.40.0
   # Commit hash from https://github.com/Azure/arm-ttk/commits/master
-  refArmttk: b98c03608a20bbee4f2061b23bdeece1c2d214b8
+  refArmttk: 06356206f9a8a5173fc124458a1486a1cc67fa31
   # Commit hash from https://github.com/Azure/azure-javaee-iaas/commits/main
   refJavaee: f25ab89a2a8848da39b84e5d6c927f4c4cb47200
   bicepVersion: v0.11.1

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -40,8 +40,6 @@ on:
   # Disable IBM DB2 database connection and keep Azure resources at the end
   # curl --verbose -X POST https://api.github.com/repos/${REPO_NAME}/dispatches -H "Accept: application/vnd.github.everest-preview+json" -H "Authorization: token ${PERSONAL_ACCESS_TOKEN}" --data '{"event_type": "integration-test", "client_payload": {"databaseType": "none", "deleteAzureResources": false}}'
 env:
-  # Commit hash from https://github.com/Azure/azure-javaee-iaas/commits/main
-  refJavaee: b728442f1921282f5f3902fe5bdf7f4d2c7872ca
   repoName: "azure.websphere-traditional.cluster"
   azureCredentials: ${{ secrets.AZURE_CREDENTIALS }}
   userName: ${{ secrets.USER_NAME }}
@@ -60,11 +58,12 @@ jobs:
     steps:
       - name: Get versions of external dependencies
         run: |
-          curl -Lo external-deps-versions.properties https://raw.githubusercontent.com/Azure/azure-javaee-iaas/main/arm-parent/src/main/resources/external-deps-versions.properties
+          curl -Lo external-deps-versions.properties https://raw.githubusercontent.com/Azure/azure-javaee-iaas/main/external-deps-versions.properties
           source external-deps-versions.properties
           echo "azCliVersion=${AZ_CLI_VERSION}" >> $GITHUB_ENV
           echo "bicepVersion=${BICEP_VERSION}" >> $GITHUB_ENV
           echo "refArmttk=${ARM_TTK_REFERENCE}" >> $GITHUB_ENV
+          echo "refJavaee=${AZURE_JAVAEE_IAAS_REFERENCE}" >> $GITHUB_ENV
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
         with:

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -40,13 +40,8 @@ on:
   # Disable IBM DB2 database connection and keep Azure resources at the end
   # curl --verbose -X POST https://api.github.com/repos/${REPO_NAME}/dispatches -H "Accept: application/vnd.github.everest-preview+json" -H "Authorization: token ${PERSONAL_ACCESS_TOKEN}" --data '{"event_type": "integration-test", "client_payload": {"databaseType": "none", "deleteAzureResources": false}}'
 env:
-  # Latest version is at https://github.com/Azure/azure-cli/releases
-  azCliVersion: 2.40.0
-  # Commit hash from https://github.com/Azure/arm-ttk/commits/master
-  refArmttk: 06356206f9a8a5173fc124458a1486a1cc67fa31
   # Commit hash from https://github.com/Azure/azure-javaee-iaas/commits/main
-  refJavaee: f25ab89a2a8848da39b84e5d6c927f4c4cb47200
-  bicepVersion: v0.11.1
+  refJavaee: b728442f1921282f5f3902fe5bdf7f4d2c7872ca
   repoName: "azure.websphere-traditional.cluster"
   azureCredentials: ${{ secrets.AZURE_CREDENTIALS }}
   userName: ${{ secrets.USER_NAME }}
@@ -63,6 +58,13 @@ jobs:
   integration-test:
     runs-on: ubuntu-latest
     steps:
+      - name: Get versions of external dependencies
+        run: |
+          curl -Lo external-deps-versions.properties https://raw.githubusercontent.com/Azure/azure-javaee-iaas/main/arm-parent/src/main/resources/external-deps-versions.properties
+          source external-deps-versions.properties
+          echo "azCliVersion=${AZ_CLI_VERSION}" >> $GITHUB_ENV
+          echo "bicepVersion=${BICEP_VERSION}" >> $GITHUB_ENV
+          echo "refArmttk=${ARM_TTK_REFERENCE}" >> $GITHUB_ENV
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
         with:

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -41,12 +41,12 @@ on:
   # curl --verbose -X POST https://api.github.com/repos/${REPO_NAME}/dispatches -H "Accept: application/vnd.github.everest-preview+json" -H "Authorization: token ${PERSONAL_ACCESS_TOKEN}" --data '{"event_type": "integration-test", "client_payload": {"databaseType": "none", "deleteAzureResources": false}}'
 env:
   # Latest version is at https://github.com/Azure/azure-cli/releases
-  azCliVersion: 2.31.0
+  azCliVersion: 2.40.0
   # Commit hash from https://github.com/Azure/arm-ttk/commits/master
-  refArmttk: cf5c927eaf1f5652556e86a6b67816fc910d1b74
+  refArmttk: b98c03608a20bbee4f2061b23bdeece1c2d214b8
   # Commit hash from https://github.com/Azure/azure-javaee-iaas/commits/main
   refJavaee: f25ab89a2a8848da39b84e5d6c927f4c4cb47200
-  bicepVersion: v0.7.4
+  bicepVersion: v0.11.1
   repoName: "azure.websphere-traditional.cluster"
   azureCredentials: ${{ secrets.AZURE_CREDENTIALS }}
   userName: ${{ secrets.USER_NAME }}

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -12,7 +12,6 @@ on:
   # REPO_NAME=WASdev/azure.websphere-traditional.cluster
   # curl --verbose -X POST https://api.github.com/repos/${REPO_NAME}/dispatches -H "Accept: application/vnd.github.everest-preview+json" -H "Authorization: token ${PERSONAL_ACCESS_TOKEN}" --data '{"event_type": "package"}'
 env:
-  refJavaee: b728442f1921282f5f3902fe5bdf7f4d2c7872ca
   repoName: "azure.websphere-traditional.cluster"
 
 jobs:
@@ -21,11 +20,12 @@ jobs:
     steps:
       - name: Get versions of external dependencies
         run: |
-          curl -Lo external-deps-versions.properties https://raw.githubusercontent.com/Azure/azure-javaee-iaas/main/arm-parent/src/main/resources/external-deps-versions.properties
+          curl -Lo external-deps-versions.properties https://raw.githubusercontent.com/Azure/azure-javaee-iaas/main/external-deps-versions.properties
           source external-deps-versions.properties
           echo "azCliVersion=${AZ_CLI_VERSION}" >> $GITHUB_ENV
           echo "bicepVersion=${BICEP_VERSION}" >> $GITHUB_ENV
           echo "refArmttk=${ARM_TTK_REFERENCE}" >> $GITHUB_ENV
+          echo "refJavaee=${AZURE_JAVAEE_IAAS_REFERENCE}" >> $GITHUB_ENV
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
         with:

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -12,9 +12,9 @@ on:
   # REPO_NAME=WASdev/azure.websphere-traditional.cluster
   # curl --verbose -X POST https://api.github.com/repos/${REPO_NAME}/dispatches -H "Accept: application/vnd.github.everest-preview+json" -H "Authorization: token ${PERSONAL_ACCESS_TOKEN}" --data '{"event_type": "package"}'
 env:
-  refArmttk: cf5c927eaf1f5652556e86a6b67816fc910d1b74
+  refArmttk: b98c03608a20bbee4f2061b23bdeece1c2d214b8
   refJavaee: f25ab89a2a8848da39b84e5d6c927f4c4cb47200
-  bicepVersion: v0.7.4
+  bicepVersion: v0.11.1
   repoName: "azure.websphere-traditional.cluster"
 
 jobs:

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -12,7 +12,7 @@ on:
   # REPO_NAME=WASdev/azure.websphere-traditional.cluster
   # curl --verbose -X POST https://api.github.com/repos/${REPO_NAME}/dispatches -H "Accept: application/vnd.github.everest-preview+json" -H "Authorization: token ${PERSONAL_ACCESS_TOKEN}" --data '{"event_type": "package"}'
 env:
-  refArmttk: b98c03608a20bbee4f2061b23bdeece1c2d214b8
+  refArmttk: 06356206f9a8a5173fc124458a1486a1cc67fa31
   refJavaee: f25ab89a2a8848da39b84e5d6c927f4c4cb47200
   bicepVersion: v0.11.1
   repoName: "azure.websphere-traditional.cluster"

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -12,15 +12,20 @@ on:
   # REPO_NAME=WASdev/azure.websphere-traditional.cluster
   # curl --verbose -X POST https://api.github.com/repos/${REPO_NAME}/dispatches -H "Accept: application/vnd.github.everest-preview+json" -H "Authorization: token ${PERSONAL_ACCESS_TOKEN}" --data '{"event_type": "package"}'
 env:
-  refArmttk: 06356206f9a8a5173fc124458a1486a1cc67fa31
-  refJavaee: f25ab89a2a8848da39b84e5d6c927f4c4cb47200
-  bicepVersion: v0.11.1
+  refJavaee: b728442f1921282f5f3902fe5bdf7f4d2c7872ca
   repoName: "azure.websphere-traditional.cluster"
 
 jobs:
   package:
     runs-on: ubuntu-latest
     steps:
+      - name: Get versions of external dependencies
+        run: |
+          curl -Lo external-deps-versions.properties https://raw.githubusercontent.com/Azure/azure-javaee-iaas/main/arm-parent/src/main/resources/external-deps-versions.properties
+          source external-deps-versions.properties
+          echo "azCliVersion=${AZ_CLI_VERSION}" >> $GITHUB_ENV
+          echo "bicepVersion=${BICEP_VERSION}" >> $GITHUB_ENV
+          echo "refArmttk=${ARM_TTK_REFERENCE}" >> $GITHUB_ENV
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
         with:

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>com.microsoft.azure.iaas</groupId>
         <artifactId>azure-javaee-iaas-parent</artifactId>
-        <version>1.0.16</version>
+        <version>1.0.18</version>
         <relativePath></relativePath>
     </parent>
     


### PR DESCRIPTION
Upgrade versions of external deps used in pipelines by referencing to the centralized config file:
- az-cli
- bicep
- arm-ttk
- azure-javaee-iaas

Signed-off-by: Jianguo Ma <jiangma@microsoft.com>