### PR TITLE
On branch edburns-msft-ibm-342-end-to-end-automation-documentation Remove conditional restricting publishing to only when run within WASdev.

### DIFF
--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -80,7 +80,6 @@ jobs:
           path: ${{steps.artifact_file.outputs.artifactPath}}
       - name: Update offer artifact
         uses: microsoft/microsoft-partner-center-github-action@v3
-        if: ${{ github.repository_owner  == 'WASdev' }}
         with:
           offerId: ${{ env.offerId }}
           planId: ${{ env.planId }}

--- a/docs/howto-update-for-was-fixpack.md
+++ b/docs/howto-update-for-was-fixpack.md
@@ -22,7 +22,7 @@ Please follow sections below in order to update the solution for next tWAS fixpa
      GPG_RPM_PUBLIC_KEY_URL=https://software.bigfix.com/download/bes/95/RPM-GPG-KEY-BigFix-9-V2
      ```
 
-     Note: these properties shouldn't be updated unless there're new versions/updates available.
+     Note: these properties shouldn't be updated unless there are new versions/updates available.
 
    * For IHS version in `ihs` image, update the following properties in file [`virtualimage.properties`](https://github.com/WASdev/azure.websphere-traditional.image/blob/main/ihs/src/main/scripts/virtualimage.properties#L14-L17), e.g.:
 


### PR DESCRIPTION
…

modified:   .github/workflows/package.yaml