### PR TITLE
Remove azure javaee in workflows

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -90,7 +90,6 @@ jobs:
           server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
           server-username: MAVEN_USERNAME # env variable for username
           server-password: MAVEN_TOKEN # env variable for token
-
       - name: Set Maven env
         env:
           MAVEN_USERNAME: github
@@ -99,21 +98,18 @@ jobs:
         run: |
           echo "MAVEN_USERNAME=${MAVEN_USERNAME}" >> "$GITHUB_ENV"
           echo "MAVEN_TOKEN=${MAVEN_TOKEN}" >> "$GITHUB_ENV"
-
       - name: Set up bicep
         run: |
           curl -Lo bicep https://github.com/Azure/bicep/releases/download/${{ env.bicepVersion }}/bicep-linux-x64
           chmod +x ./bicep
           sudo mv ./bicep /usr/local/bin/bicep
           bicep --version
-
       - name: Checkout arm-ttk
         uses: actions/checkout@v3
         with:
           repository: Azure/arm-ttk
           path: arm-ttk
           ref: ${{ env.refArmttk }}
-
       - name: Checkout ${{ env.repoName }}
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -109,7 +109,6 @@ jobs:
         with:
           repository: Azure/arm-ttk
           path: arm-ttk
-          ref: ${{ env.refArmttk }}
       - name: Checkout ${{ env.repoName }}
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -107,11 +107,12 @@ jobs:
           sudo mv ./bicep /usr/local/bin/bicep
           bicep --version
 
-      - name: Download arm-ttk used in partner center pipeline
-        shell: bash
-        run: |
-          wget -O arm-template-toolkit.zip https://aka.ms/arm-ttk-azureapps
-          unzip arm-template-toolkit.zip -d arm-ttk
+      - name: Checkout arm-ttk
+        uses: actions/checkout@v3
+        with:
+          repository: Azure/arm-ttk
+          path: arm-ttk
+          ref: ${{ env.refArmttk }}
 
       - name: Checkout ${{ env.repoName }}
         uses: actions/checkout@v3

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -81,33 +81,38 @@ jobs:
         run: |
           curl -Lo external-deps-versions.properties https://raw.githubusercontent.com/Azure/azure-javaee-iaas/main/external-deps-versions.properties
           source external-deps-versions.properties
-          echo "azCliVersion=${AZ_CLI_VERSION}" >> $GITHUB_ENV
           echo "bicepVersion=${BICEP_VERSION}" >> $GITHUB_ENV
-          echo "refArmttk=${ARM_TTK_REFERENCE}" >> $GITHUB_ENV
-          echo "refJavaee=${AZURE_JAVAEE_IAAS_REFERENCE}" >> $GITHUB_ENV
       - name: Set up JDK 11
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
           java-version: '11'
+          server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
+          server-username: MAVEN_USERNAME # env variable for username
+          server-password: MAVEN_TOKEN # env variable for token
+
+      - name: Set Maven env
+        env:
+          MAVEN_USERNAME: github
+          MAVEN_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          echo "MAVEN_USERNAME=${MAVEN_USERNAME}" >> "$GITHUB_ENV"
+          echo "MAVEN_TOKEN=${MAVEN_TOKEN}" >> "$GITHUB_ENV"
+
       - name: Set up bicep
         run: |
           curl -Lo bicep https://github.com/Azure/bicep/releases/download/${{ env.bicepVersion }}/bicep-linux-x64
           chmod +x ./bicep
           sudo mv ./bicep /usr/local/bin/bicep
           bicep --version
-      - name: Checkout azure-javaee-iaas
-        uses: actions/checkout@v3
-        with:
-          repository: Azure/azure-javaee-iaas
-          path: azure-javaee-iaas
-          ref: ${{ env.refJavaee }}
-      - name: Checkout arm-ttk
-        uses: actions/checkout@v3
-        with:
-          repository: Azure/arm-ttk
-          path: arm-ttk
-          ref: ${{ env.refArmttk }}
+
+      - name: Download arm-ttk used in partner center pipeline
+        shell: bash
+        run: |
+          wget -O arm-template-toolkit.zip https://aka.ms/arm-ttk-azureapps
+          unzip arm-template-toolkit.zip -d arm-ttk
+
       - name: Checkout ${{ env.repoName }}
         uses: actions/checkout@v3
         with:
@@ -118,8 +123,6 @@ jobs:
         with:
           repository: Azure-Samples/websphere-cafe
           path: websphere-cafe
-      - name: Build azure-javaee-iaas
-        run: mvn -DskipTests clean install --file azure-javaee-iaas/pom.xml
       - uses: azure/login@v1
         id: azure-login
         with:

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -1,6 +1,6 @@
 # Copyright (c) IBM Corporation.
 # Copyright (c) Microsoft Corporation.
-name: Package ARM
+name: Package ARM and Update Offer Artifact
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -58,11 +58,10 @@ jobs:
           chmod +x ./bicep
           sudo mv ./bicep /usr/local/bin/bicep
           bicep --version
-      - name: Checkout arm-ttk
-        uses: actions/checkout@v3
-        with:
-          repository: Azure/arm-ttk
-          path: arm-ttk
+      - name: Download arm-ttk used in partner center pipeline
+        run: |
+          wget -O arm-template-toolkit.zip https://aka.ms/arm-ttk-azureapps
+          unzip arm-template-toolkit.zip -d arm-ttk
       - name: Checkout ${{ env.repoName }}
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -30,26 +30,32 @@ jobs:
         run: |
           curl -Lo external-deps-versions.properties https://raw.githubusercontent.com/Azure/azure-javaee-iaas/main/external-deps-versions.properties
           source external-deps-versions.properties
-          echo "azCliVersion=${AZ_CLI_VERSION}" >> $GITHUB_ENV
           echo "bicepVersion=${BICEP_VERSION}" >> $GITHUB_ENV
-          echo "refArmttk=${ARM_TTK_REFERENCE}" >> $GITHUB_ENV
-          echo "refJavaee=${AZURE_JAVAEE_IAAS_REFERENCE}" >> $GITHUB_ENV
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
         with:
-          java-version: 1.8
+          distribution: 'temurin'
+          java-version: '11'
+          server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
+          server-username: MAVEN_USERNAME # env variable for username
+          server-password: MAVEN_TOKEN # env variable for token
+
+      - name: Set Maven env
+        env:
+          MAVEN_USERNAME: github
+          MAVEN_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          echo "MAVEN_USERNAME=${MAVEN_USERNAME}" >> "$GITHUB_ENV"
+          echo "MAVEN_TOKEN=${MAVEN_TOKEN}" >> "$GITHUB_ENV"
+
       - name: Set up bicep
         run: |
           curl -Lo bicep https://github.com/Azure/bicep/releases/download/${{ env.bicepVersion }}/bicep-linux-x64
           chmod +x ./bicep
           sudo mv ./bicep /usr/local/bin/bicep
           bicep --version
-      - name: Checkout azure-javaee-iaas
-        uses: actions/checkout@v2
-        with:
-          repository: Azure/azure-javaee-iaas
-          path: azure-javaee-iaas
-          ref: ${{ env.refJavaee }}
+
       - name: Download arm-ttk used in partner center pipeline
         run: |
           wget -O arm-template-toolkit.zip https://aka.ms/arm-ttk-azureapps
@@ -59,8 +65,7 @@ jobs:
         with:
           path: ${{ env.repoName }}
           ref: ${{ github.event.inputs.ref }}
-      - name: Build azure-javaee-iaas
-        run: mvn -DskipTests clean install --file azure-javaee-iaas/pom.xml
+
       - name: Build and test ${{ env.repoName }}
         run: |
           cd ${{ env.repoName }}

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -8,7 +8,7 @@ on:
         description: 'Update offer artifact'
         required: true
         type: boolean
-        default: false
+        default: true
   # Allows you to run this workflow using GitHub APIs
   # PERSONAL_ACCESS_TOKEN=<GITHUB_PERSONAL_ACCESS_TOKEN>
   # REPO_NAME=WASdev/azure.websphere-traditional.cluster

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -52,10 +52,11 @@ jobs:
           chmod +x ./bicep
           sudo mv ./bicep /usr/local/bin/bicep
           bicep --version
-      - name: Download arm-ttk used in partner center pipeline
-        run: |
-          wget -O arm-template-toolkit.zip https://aka.ms/arm-ttk-azureapps
-          unzip arm-template-toolkit.zip -d arm-ttk
+      - name: Checkout arm-ttk
+        uses: actions/checkout@v3
+        with:
+          repository: Azure/arm-ttk
+          path: arm-ttk
       - name: Checkout ${{ env.repoName }}
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -31,11 +31,10 @@ jobs:
           curl -Lo external-deps-versions.properties https://raw.githubusercontent.com/Azure/azure-javaee-iaas/main/external-deps-versions.properties
           source external-deps-versions.properties
           echo "bicepVersion=${BICEP_VERSION}" >> $GITHUB_ENV
-      - name: Set up JDK 11
-        uses: actions/setup-java@v3
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
         with:
-          distribution: 'temurin'
-          java-version: '11'
+          java-version: 1.8
           server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
           server-username: MAVEN_USERNAME # env variable for username
           server-password: MAVEN_TOKEN # env variable for token

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -3,6 +3,12 @@
 name: Package ARM
 on:
   workflow_dispatch:
+    inputs:
+      updateOfferArtifact:
+        description: 'Update offer artifact'
+        required: true
+        type: boolean
+        default: false
   # Allows you to run this workflow using GitHub APIs
   # PERSONAL_ACCESS_TOKEN=<GITHUB_PERSONAL_ACCESS_TOKEN>
   # REPO_NAME=WASdev/azure.websphere-traditional.cluster
@@ -82,6 +88,7 @@ jobs:
           name: ${{steps.artifact_file.outputs.artifactName}}
           path: ${{steps.artifact_file.outputs.artifactPath}}
       - name: Update offer artifact
+        if: ${{ inputs.updateOfferArtifact == true || github.event.client_payload.updateOfferArtifact == true }}
         uses: microsoft/microsoft-partner-center-github-action@v3
         with:
           offerId: ${{ env.offerId }}

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -38,7 +38,6 @@ jobs:
           server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
           server-username: MAVEN_USERNAME # env variable for username
           server-password: MAVEN_TOKEN # env variable for token
-
       - name: Set Maven env
         env:
           MAVEN_USERNAME: github
@@ -47,14 +46,12 @@ jobs:
         run: |
           echo "MAVEN_USERNAME=${MAVEN_USERNAME}" >> "$GITHUB_ENV"
           echo "MAVEN_TOKEN=${MAVEN_TOKEN}" >> "$GITHUB_ENV"
-
       - name: Set up bicep
         run: |
           curl -Lo bicep https://github.com/Azure/bicep/releases/download/${{ env.bicepVersion }}/bicep-linux-x64
           chmod +x ./bicep
           sudo mv ./bicep /usr/local/bin/bicep
           bicep --version
-
       - name: Download arm-ttk used in partner center pipeline
         run: |
           wget -O arm-template-toolkit.zip https://aka.ms/arm-ttk-azureapps
@@ -64,7 +61,6 @@ jobs:
         with:
           path: ${{ env.repoName }}
           ref: ${{ github.event.inputs.ref }}
-
       - name: Build and test ${{ env.repoName }}
         run: |
           cd ${{ env.repoName }}

--- a/README.md
+++ b/README.md
@@ -32,10 +32,18 @@ Please follow these steps:
     - Click Generate token and make sure to copy the token.
 
 2. Configure Maven Settings
-    - Locate or create the settings.xml file in your .m2 directory.
+    - Locate or create the settings.xml file in your .m2 directory(~/.m2/settings.xml).
     - Add the GitHub Package Registry server configuration with your username and the PAT you just created. It should look something like this:
        ```xml
-        <settings>
+        <settings xmlns="http://maven.apache.org/SETTINGS/1.2.0"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.2.0 
+                               https://maven.apache.org/xsd/settings-1.2.0.xsd">
+         
+       <!-- other settings
+       ...
+       -->
+      
          <servers>
            <server>
              <id>github</id>
@@ -43,6 +51,11 @@ Please follow these steps:
              <password>YOUR_PERSONAL_ACCESS_TOKEN</password>
            </server>
          </servers>
+      
+       <!-- other settings
+       ...
+       -->
+      
         </settings>
        ```
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,34 @@
 1. Install [Maven](https://maven.apache.org/download.cgi).
 1. Install [`jq`](https://stedolan.github.io/jq/download/).
 
+## Local Build Setup and Requirements
+This project utilizes [GitHub Packages](https://github.com/features/packages) for hosting and retrieving some dependencies. To ensure you can smoothly run and build the project in your local environment, specific configuration settings are required.
+
+GitHub Packages requires authentication to download or publish packages. Therefore, you need to configure your Maven `settings.xml` file to authenticate using your GitHub credentials. The primary reason for this is that GitHub Packages does not support anonymous access, even for public packages.
+
+Please follow these steps:
+
+1. Create a Personal Access Token (PAT)
+    - Go to [Personal access tokens](https://github.com/settings/tokens).
+    - Click on Generate new token.
+    - Give your token a descriptive name, set the expiration as needed, and select the scopes (read:packages, write:packages).
+    - Click Generate token and make sure to copy the token.
+
+2. Configure Maven Settings
+    - Locate or create the settings.xml file in your .m2 directory.
+    - Add the GitHub Package Registry server configuration with your username and the PAT you just created. It should look something like this:
+       ```xml
+        <settings>
+         <servers>
+           <server>
+             <id>github</id>
+             <username>YOUR_GITHUB_USERNAME</username>
+             <password>YOUR_PERSONAL_ACCESS_TOKEN</password>
+           </server>
+         </servers>
+        </settings>
+       ```
+
 ## Steps of deployment
 
 1. Checkout [azure-javaee-iaas](https://github.com/Azure/azure-javaee-iaas)

--- a/docs/howto-update-for-was-fixpack.md
+++ b/docs/howto-update-for-was-fixpack.md
@@ -87,7 +87,7 @@ Please follow sections below in order to update the solution for next tWAS fixpa
 Note: **Wait for images to be published before proceeding with this step.** The steps included in this section are also applied to release new features / bug fixes which have no changes to the images.
 
 1. How to update the version of the solution?
-   * Increase the [version number](https://github.com/WASdev/azure.websphere-traditional.cluster/blob/main/pom.xml#L40) of the `version.azure.websphere-traditional.cluster` property, which is specified in the `pom.xml`.
+   * Increase the [version number](https://github.com/WASdev/azure.websphere-traditional.cluster/blob/main/pom.xml#L23) which is specified in the `pom.xml`.
    * Also update the [`twasNdImageVersion`](https://github.com/WASdev/azure.websphere-traditional.cluster/blob/main/src/main/bicep/config.json#L17) and [`ihsImageVersion`](https://github.com/WASdev/azure.websphere-traditional.cluster/blob/main/src/main/bicep/config.json#L23) in the `config.json` (obtained from publish step)
    * If creating a new Plan, update the `pid` value as described in [How Azure customer usage attribution works in the IBM Partner Center offers](https://github.com/WASdev/azure.websphere-traditional.image/blob/main/docs/howto-update-pids.md).
    * Get the PR merged

--- a/docs/howto-update-for-was-fixpack.md
+++ b/docs/howto-update-for-was-fixpack.md
@@ -87,7 +87,7 @@ Please follow sections below in order to update the solution for next tWAS fixpa
 Note: **Wait for images to be published before proceeding with this step.** The steps included in this section are also applied to release new features / bug fixes which have no changes to the images.
 
 1. How to update the version of the solution?
-   * Increase the [version number](https://github.com/WASdev/azure.websphere-traditional.cluster/blob/main/pom.xml#L23) which is specified in the `pom.xml`
+   * Increase the [version number](https://github.com/WASdev/azure.websphere-traditional.cluster/blob/main/pom.xml#L40) of the `version.azure.websphere-traditional.cluster` property, which is specified in the `pom.xml`.
    * Also update the [`twasNdImageVersion`](https://github.com/WASdev/azure.websphere-traditional.cluster/blob/main/src/main/bicep/config.json#L17) and [`ihsImageVersion`](https://github.com/WASdev/azure.websphere-traditional.cluster/blob/main/src/main/bicep/config.json#L23) in the `config.json` (obtained from publish step)
    * If creating a new Plan, update the `pid` value as described in [How Azure customer usage attribution works in the IBM Partner Center offers](https://github.com/WASdev/azure.websphere-traditional.image/blob/main/docs/howto-update-pids.md).
    * Get the PR merged

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>com.ibm.websphere.azure</groupId>
     <artifactId>azure.websphere-traditional.cluster</artifactId>
-    <version>${version.azure.websphere-traditional.cluster}</version>
+    <version>1.3.56</version>
 
     <!-- mvn -Pbicep -Passembly clean install -Ptemplate-validation-tests -->
     <parent>
@@ -37,7 +37,6 @@
     <properties>
         <git.repo>WASdev</git.repo>
         <artifactsLocationBase>https://raw.githubusercontent.com/${git.repo}/${project.artifactId}/${git.tag}</artifactsLocationBase>
-        <version.azure.websphere-traditional.cluster>1.3.56</version.azure.websphere-traditional.cluster>
     </properties>
 
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>com.microsoft.azure.iaas</groupId>
         <artifactId>azure-javaee-iaas-parent</artifactId>
-        <version>1.0.22</version>
+        <version>${version.azure.websphere-traditional.cluster}</version>
         <relativePath></relativePath>
     </parent>
 
@@ -37,6 +37,7 @@
     <properties>
         <git.repo>WASdev</git.repo>
         <artifactsLocationBase>https://raw.githubusercontent.com/${git.repo}/${project.artifactId}/${git.tag}</artifactsLocationBase>
+        <version.azure.websphere-traditional.cluster>1.0.22</version.azure.websphere-traditional.cluster>
     </properties>
 
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>com.microsoft.azure.iaas</groupId>
         <artifactId>azure-javaee-iaas-parent</artifactId>
-        <version>1.0.20</version>
+        <version>1.0.22</version>
         <relativePath></relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -21,13 +21,13 @@
 
     <groupId>com.ibm.websphere.azure</groupId>
     <artifactId>azure.websphere-traditional.cluster</artifactId>
-    <version>1.3.56</version>
+    <version>${version.azure.websphere-traditional.cluster}</version>
 
     <!-- mvn -Pbicep -Passembly clean install -Ptemplate-validation-tests -->
     <parent>
         <groupId>com.microsoft.azure.iaas</groupId>
         <artifactId>azure-javaee-iaas-parent</artifactId>
-        <version>${version.azure.websphere-traditional.cluster}</version>
+        <version>1.0.22</version>
         <relativePath></relativePath>
     </parent>
 
@@ -37,7 +37,7 @@
     <properties>
         <git.repo>WASdev</git.repo>
         <artifactsLocationBase>https://raw.githubusercontent.com/${git.repo}/${project.artifactId}/${git.tag}</artifactsLocationBase>
-        <version.azure.websphere-traditional.cluster>1.0.22</version.azure.websphere-traditional.cluster>
+        <version.azure.websphere-traditional.cluster>1.3.56</version.azure.websphere-traditional.cluster>
     </properties>
 
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -27,10 +27,10 @@
     <parent>
         <groupId>com.microsoft.azure.iaas</groupId>
         <artifactId>azure-javaee-iaas-parent</artifactId>
-        <version>1.0.19</version>
+        <version>1.0.20</version>
         <relativePath></relativePath>
     </parent>
-    
+
     <packaging>jar</packaging>
     <name>${project.artifactId}</name>
 
@@ -38,4 +38,20 @@
         <git.repo>WASdev</git.repo>
         <artifactsLocationBase>https://raw.githubusercontent.com/${git.repo}/${project.artifactId}/${git.tag}</artifactsLocationBase>
     </properties>
+
+    <repositories>
+        <repository>
+            <id>github</id>
+            <name>GitHub Packages</name>
+            <url>https://maven.pkg.github.com/azure-javaee/azure-javaee-iaas</url>
+        </repository>
+    </repositories>
+
+    <pluginRepositories>
+        <pluginRepository>
+            <id>github</id>
+            <name>GitHub Packages</name>
+            <url>https://maven.pkg.github.com/azure-javaee/azure-javaee-iaas</url>
+        </pluginRepository>
+    </pluginRepositories>
 </project>

--- a/src/main/bicep/mainTemplate.bicep
+++ b/src/main/bicep/mainTemplate.bicep
@@ -257,7 +257,7 @@ module uamiDeployment 'modules/_uami/_uamiAndRoles.bicep' = if (const_configureA
   }
 }
 
-resource storageAccount 'Microsoft.Storage/storageAccounts@2023-01-01' = {
+resource storageAccount 'Microsoft.Storage/storageAccounts@2023-05-01' = {
   name: name_storageAccount
   location: location
   sku: {
@@ -266,7 +266,7 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2023-01-01' = {
   kind: 'StorageV2'
 }
 
-resource storageAccountPrivateEndpoint 'Microsoft.Network/privateEndpoints@2023-06-01' = if (const_configureIHS) {
+resource storageAccountPrivateEndpoint 'Microsoft.Network/privateEndpoints@2023-11-01' = if (const_configureIHS) {
   name: name_storageAccountPrivateEndpoint
   location: location
   properties: {
@@ -292,12 +292,12 @@ resource storageAccountPrivateEndpoint 'Microsoft.Network/privateEndpoints@2023-
   ]
 }
 
-resource storageAccountFileSvc 'Microsoft.Storage/storageAccounts/fileServices@2023-01-01' = if (const_configureIHS) {
+resource storageAccountFileSvc 'Microsoft.Storage/storageAccounts/fileServices@2023-05-01' = if (const_configureIHS) {
   parent: storageAccount
   name: 'default'
 }
 
-resource storageAccountFileShare 'Microsoft.Storage/storageAccounts/fileServices/shares@2023-01-01' = if (const_configureIHS) {
+resource storageAccountFileShare 'Microsoft.Storage/storageAccounts/fileServices/shares@2023-05-01' = if (const_configureIHS) {
   parent: storageAccountFileSvc
   name: name_share
   properties: {
@@ -305,7 +305,7 @@ resource storageAccountFileShare 'Microsoft.Storage/storageAccounts/fileServices
   }
 }
 
-resource networkSecurityGroup 'Microsoft.Network/networkSecurityGroups@2023-06-01' = if (const_newVNet) {
+resource networkSecurityGroup 'Microsoft.Network/networkSecurityGroups@2023-11-01' = if (const_newVNet) {
   name: name_networkSecurityGroup
   location: location
   properties: {
@@ -367,7 +367,7 @@ resource networkSecurityGroup 'Microsoft.Network/networkSecurityGroups@2023-06-0
   }
 }
 
-resource virtualNetwork 'Microsoft.Network/virtualNetworks@2023-06-01' = if (const_newVNet) {
+resource virtualNetwork 'Microsoft.Network/virtualNetworks@2023-11-01' = if (const_newVNet) {
   name: vnetForCluster.name
   location: location
   properties: {
@@ -407,22 +407,22 @@ resource virtualNetwork 'Microsoft.Network/virtualNetworks@2023-06-01' = if (con
   }
 }
 
-resource existingVNet 'Microsoft.Network/virtualNetworks@2023-06-01' existing = if (!const_newVNet) {
+resource existingVNet 'Microsoft.Network/virtualNetworks@2023-11-01' existing = if (!const_newVNet) {
   name: vnetForCluster.name
   scope: resourceGroup(vnetRGNameForCluster)
 }
 
-resource existingAppGwSubnet 'Microsoft.Network/virtualNetworks/subnets@2023-06-01' existing = if (!const_newVNet && const_configureAppGw) {
+resource existingAppGwSubnet 'Microsoft.Network/virtualNetworks/subnets@2023-11-01' existing = if (!const_newVNet && const_configureAppGw) {
   parent: existingVNet
   name: vnetForCluster.subnets.gatewaySubnet.name
 }
 
-resource existingClusterSubnet 'Microsoft.Network/virtualNetworks/subnets@2023-06-01' existing = if (!const_newVNet) {
+resource existingClusterSubnet 'Microsoft.Network/virtualNetworks/subnets@2023-11-01' existing = if (!const_newVNet) {
   parent: existingVNet
   name: vnetForCluster.subnets.clusterSubnet.name
 }
 
-resource publicIPAddress 'Microsoft.Network/publicIPAddresses@2023-06-01' = if (const_newVNet) {
+resource publicIPAddress 'Microsoft.Network/publicIPAddresses@2023-11-01' = if (const_newVNet) {
   name: name_publicIPAddress
   location: location
   properties: {
@@ -433,7 +433,7 @@ resource publicIPAddress 'Microsoft.Network/publicIPAddresses@2023-06-01' = if (
   }
 }
 
-resource dmgrVMNetworkInterface 'Microsoft.Network/networkInterfaces@2023-06-01' = if (const_newVNet) {
+resource dmgrVMNetworkInterface 'Microsoft.Network/networkInterfaces@2023-11-01' = if (const_newVNet) {
   name: '${name_dmgrVM}-if'
   location: location
   properties: {
@@ -460,7 +460,7 @@ resource dmgrVMNetworkInterface 'Microsoft.Network/networkInterfaces@2023-06-01'
   ]
 }
 
-resource dmgrVMNetworkInterfaceNoPubIp 'Microsoft.Network/networkInterfaces@2023-06-01' = if (!const_newVNet) {
+resource dmgrVMNetworkInterfaceNoPubIp 'Microsoft.Network/networkInterfaces@2023-11-01' = if (!const_newVNet) {
   name: '${name_dmgrVM}-no-pub-ip-if'
   location: location
   properties: {
@@ -478,7 +478,7 @@ resource dmgrVMNetworkInterfaceNoPubIp 'Microsoft.Network/networkInterfaces@2023
   }
 }
 
-resource managedVMNetworkInterfaces 'Microsoft.Network/networkInterfaces@2023-06-01' = [for i in range(0, (numberOfNodes - 1)): {
+resource managedVMNetworkInterfaces 'Microsoft.Network/networkInterfaces@2023-11-01' = [for i in range(0, (numberOfNodes - 1)): {
   name: '${const_managedVMPrefix}${(i + 1)}-if'
   location: location
   properties: {
@@ -573,7 +573,7 @@ module appGatewayEndPid './modules/_pids/_empty.bicep' = if (const_configureAppG
   ]
 }
 
-resource clusterVMs 'Microsoft.Compute/virtualMachines@2023-07-01' = [for i in range(0, numberOfNodes): {
+resource clusterVMs 'Microsoft.Compute/virtualMachines@2024-03-01' = [for i in range(0, numberOfNodes): {
   name: i == 0 ? name_dmgrVM : '${const_managedVMPrefix}${i}'
   location: location
   properties: {
@@ -645,7 +645,7 @@ module dbConnectionStartPid './modules/_pids/_empty.bicep' = if (enableDB) {
   ]
 }
 
-resource clusterVMsExtension 'Microsoft.Compute/virtualMachines/extensions@2023-07-01' = [for i in range(0, numberOfNodes): {
+resource clusterVMsExtension 'Microsoft.Compute/virtualMachines/extensions@2024-04-01' = [for i in range(0, numberOfNodes): {
   name: format('{0}/install', i == 0 ? name_dmgrVM : '${const_managedVMPrefix}${i}')
   location: location
   properties: {
@@ -701,7 +701,7 @@ module ihsStartPid './modules/_pids/_empty.bicep' = if (const_configureIHS) {
   }
 }
 
-resource ihsPublicIPAddress 'Microsoft.Network/publicIPAddresses@2023-06-01' = if (const_configureIHS && const_newVNet) {
+resource ihsPublicIPAddress 'Microsoft.Network/publicIPAddresses@2023-11-01' = if (const_configureIHS && const_newVNet) {
   name: name_ihsPublicIPAddress
   location: location
   properties: {
@@ -712,7 +712,7 @@ resource ihsPublicIPAddress 'Microsoft.Network/publicIPAddresses@2023-06-01' = i
   }
 }
 
-resource ihsVMNetworkInterface 'Microsoft.Network/networkInterfaces@2023-06-01' = if (const_configureIHS && const_newVNet) {
+resource ihsVMNetworkInterface 'Microsoft.Network/networkInterfaces@2023-11-01' = if (const_configureIHS && const_newVNet) {
   name: '${name_ihsVM}-if'
   location: location
   properties: {
@@ -739,7 +739,7 @@ resource ihsVMNetworkInterface 'Microsoft.Network/networkInterfaces@2023-06-01' 
   ]
 }
 
-resource ihsVMNetworkInterfaceNoPubIp 'Microsoft.Network/networkInterfaces@2023-06-01' = if (const_configureIHS && !const_newVNet) {
+resource ihsVMNetworkInterfaceNoPubIp 'Microsoft.Network/networkInterfaces@2023-11-01' = if (const_configureIHS && !const_newVNet) {
   name: '${name_ihsVM}-no-pub-ip-if'
   location: location
   properties: {
@@ -757,7 +757,7 @@ resource ihsVMNetworkInterfaceNoPubIp 'Microsoft.Network/networkInterfaces@2023-
   }
 }
 
-resource ihsVM 'Microsoft.Compute/virtualMachines@2023-07-01' = if (const_configureIHS) {
+resource ihsVM 'Microsoft.Compute/virtualMachines@2024-04-01' = if (const_configureIHS) {
   name: name_ihsVM
   location: location
   properties: {
@@ -816,7 +816,7 @@ module ihsVMCreated './modules/_pids/_empty.bicep' = if (const_configureIHS) {
   ]
 }
 
-resource ihsVMExtension 'Microsoft.Compute/virtualMachines/extensions@2023-07-01' = if (const_configureIHS) {
+resource ihsVMExtension 'Microsoft.Compute/virtualMachines/extensions@2024-04-01' = if (const_configureIHS) {
   parent: ihsVM
   name: 'install'
   location: location

--- a/src/main/bicep/modules/_appgateway.bicep
+++ b/src/main/bicep/modules/_appgateway.bicep
@@ -33,7 +33,7 @@ param workerNodePrefix string
 var name_appGateway = appGatewayName
 
 // get key vault object from a resource group
-resource existingKeyvault 'Microsoft.KeyVault/vaults@2022-07-01' existing = {
+resource existingKeyvault 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
   name: keyVaultName
   scope: resourceGroup()
 }

--- a/src/main/bicep/modules/_azure-resources/_appGateway.bicep
+++ b/src/main/bicep/modules/_azure-resources/_appGateway.bicep
@@ -69,7 +69,7 @@ var obj_frontendIPConfigurations1 = [
   }
 ]
 
-resource gatewayPublicIP 'Microsoft.Network/publicIPAddresses@2022-05-01' = {
+resource gatewayPublicIP 'Microsoft.Network/publicIPAddresses@2023-11-01' = {
   name: gatewayPublicIPAddressName
   sku: {
     name: 'Standard'
@@ -83,7 +83,7 @@ resource gatewayPublicIP 'Microsoft.Network/publicIPAddresses@2022-05-01' = {
   }
 }
 
-resource wafv2AppGateway 'Microsoft.Network/applicationGateways@2022-05-01' = {
+resource wafv2AppGateway 'Microsoft.Network/applicationGateways@2023-11-01' = {
   name: name_appGateway
   location: location
   properties: {

--- a/src/main/bicep/modules/_azure-resources/_keyvault/_keyvaultWithNewCert.bicep
+++ b/src/main/bicep/modules/_azure-resources/_keyvault/_keyvaultWithNewCert.bicep
@@ -45,7 +45,7 @@ param utcValue string = utcNow()
 
 var const_identityId = substring(string(identity.userAssignedIdentities), indexOf(string(identity.userAssignedIdentities), '"') + 1, lastIndexOf(string(identity.userAssignedIdentities), '"') - (indexOf(string(identity.userAssignedIdentities), '"') + 1))
 
-resource keyvault 'Microsoft.KeyVault/vaults@2023-02-01' = {
+resource keyvault 'Microsoft.KeyVault/vaults@2023-07-01' = {
   name: keyVaultName
   location: location
   properties: {


### PR DESCRIPTION
This pull request includes changes to the GitHub Action workflows and Maven configuration in the project. The most significant changes are the removal of some environment variables and the checkout step for `azure-javaee-iaas` in the GitHub workflows, the addition of input parameters and Maven environment setup in the workflows, and the update of Maven parent version and the addition of GitHub Packages repository in the `pom.xml` file. 

Changes to GitHub workflows:

* `.github/workflows/integration-test.yaml` and `.github/workflows/package.yaml`: Removed environment variables `azCliVersion`, `refArmttk`, and `refJavaee`, and the checkout step for `azure-javaee-iaas`. Added Maven environment setup steps and input parameters for the workflows. 
  
Changes to Maven configuration:

* [`pom.xml`](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L30-R30): Updated the Maven parent version from `1.0.19` to `1.0.22` and added GitHub Packages repository for hosting and retrieving dependencies. 

Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R21-R48): Added instructions for setting up GitHub Packages in the local build environment.