### PR TITLE
BugFix: Offers can' be redeployed with the same resource group as before with different region in the same subscription

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -355,7 +355,7 @@ jobs:
       - name: Generate artifact file name and path
         id: artifact_file
         run: |
-          version=$(awk '/<version>[^<]+<\/version>/{gsub(/<version>|<\/version>/,"",$1);print $1;exit;}' ${{ env.repoName }}/pom.xml)
+          version=$(mvn -q -Dexec.executable=echo -Dexec.args='${version.${{ env.repoName }}}' --file ${{ env.repoName }}/pom.xml --non-recursive exec:exec)
           artifactName=${{ env.repoName }}-$version-arm-assembly
           unzip ${{ env.repoName }}/target/$artifactName.zip -d ${{ env.repoName }}/target/$artifactName
           echo "##[set-output name=artifactName;]${artifactName}"

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -74,7 +74,7 @@ jobs:
       - name: Generate artifact file name and path
         id: artifact_file
         run: |
-          version=$(awk '/<version>[^<]+<\/version>/{gsub(/<version>|<\/version>/,"",$1);print $1;exit;}' ${{ env.repoName }}/pom.xml)
+          version=$(mvn -q -Dexec.executable=echo -Dexec.args='${version.${{ env.repoName }}}' --file ${{ env.repoName }}/pom.xml  --non-recursive exec:exec)
           artifactName=${{ env.repoName }}-$version-arm-assembly
           unzip ${{ env.repoName }}/target/$artifactName.zip -d ${{ env.repoName }}/target/$artifactName
           echo "##[set-output name=artifactName;]${artifactName}"

--- a/pom.xml
+++ b/pom.xml
@@ -19,10 +19,6 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>com.ibm.websphere.azure</groupId>
-    <artifactId>azure.websphere-traditional.cluster</artifactId>
-    <version>1.3.58</version>
-
     <!-- mvn -Pbicep -Passembly clean install -Ptemplate-validation-tests -->
     <parent>
         <groupId>com.microsoft.azure.iaas</groupId>
@@ -31,12 +27,17 @@
         <relativePath></relativePath>
     </parent>
 
+    <groupId>com.ibm.websphere.azure</groupId>
+    <artifactId>azure.websphere-traditional.cluster</artifactId>
+    <version>${version.azure.websphere-traditional.cluster}</version>
+
     <packaging>jar</packaging>
     <name>${project.artifactId}</name>
 
     <properties>
         <git.repo>WASdev</git.repo>
         <artifactsLocationBase>https://raw.githubusercontent.com/${git.repo}/${project.artifactId}/${git.tag}</artifactsLocationBase>
+        <version.azure.websphere-traditional.cluster>1.3.58</version.azure.websphere-traditional.cluster>
     </properties>
 
     <repositories>

--- a/src/main/bicep/modules/_uami/_uamiAndRoles.bicep
+++ b/src/main/bicep/modules/_uami/_uamiAndRoles.bicep
@@ -16,11 +16,11 @@
 */
 
 param location string
+param name_deploymentScriptContributorRoleAssignmentName string = newGuid()
 
 // https://docs.microsoft.com/en-us/azure/role-based-access-control/built-in-roles
 var const_roleDefinitionIdOfContributor = 'b24988ac-6180-42a0-ab88-20f7382dd24c'
-var name_deploymentScriptUserDefinedManagedIdentity = 'twascluster-vm-deployment-script-user-defined-managed-itentity'
-var name_deploymentScriptContributorRoleAssignmentName = guid('${resourceGroup().id}${name_deploymentScriptUserDefinedManagedIdentity}Deployment Script')
+var name_deploymentScriptUserDefinedManagedIdentity = 'twascluster-vm-deployment-script-user-defined-managed-itentity-${substring(uniqueString(name_deploymentScriptContributorRoleAssignmentName),0,5)}'
 
 // UAMI for deployment script
 resource uamiForDeploymentScript 'Microsoft.ManagedIdentity/userAssignedIdentities@${azure.apiVersionForIdentity}' = {


### PR DESCRIPTION
## Context
If I try to do following steps, it will fail.
Step 1. Deploy current offer in resource group rg-a and region east us
Step 2. Delete resource group rg-a
Step 3. Deploy current offer in resource group rg-a and region west us

And this PR is used to fix this bug.


## Test Results
- [Package ARM and Update Offer Artifact #36](https://github.com/azure-javaee/azure.websphere-traditional.cluster/actions/runs/9065174969)
- [integration-test #37](https://github.com/azure-javaee/azure.websphere-traditional.cluster/actions/runs/9065171803)

<img width="1113" alt="image" src="https://github.com/WASdev/azure.websphere-traditional.cluster/assets/4465723/d6a8c1d8-cb5a-481e-b237-a6de80982930">
