### PR TITLE
Refactor: Configure Bicep Apiversions with properties file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>com.ibm.websphere.azure</groupId>
     <artifactId>azure.websphere-traditional.cluster</artifactId>
-    <version>1.3.57</version>
+    <version>1.3.58</version>
 
     <!-- mvn -Pbicep -Passembly clean install -Ptemplate-validation-tests -->
     <parent>

--- a/pom.xml
+++ b/pom.xml
@@ -54,4 +54,28 @@
             <url>https://maven.pkg.github.com/azure-javaee/azure-javaee-iaas</url>
         </pluginRepository>
     </pluginRepositories>
+
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>properties-maven-plugin</artifactId>
+                <version>1.2.1</version>
+                <executions>
+                    <execution>
+                        <phase>initialize</phase>
+                        <goals>
+                            <goal>read-project-properties</goal>
+                        </goals>
+                        <configuration>
+                            <urls>
+                                <file>file:///${basedir}/src/main/resources/azure-common.properties</file>
+                            </urls>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/src/main/bicep/mainTemplate.bicep
+++ b/src/main/bicep/mainTemplate.bicep
@@ -210,7 +210,7 @@ var name_publicIPAddress = '${name_dmgrVM}-ip'
 var name_share = 'wasshare'
 var name_storageAccount = 'storage${guidValue}'
 var name_storageAccountPrivateEndpoint = 'storagepe${guidValue}'
-var ref_storageAccountPrivateEndpoint = const_configureIHS ? reference(name_storageAccountPrivateEndpoint, '2023-06-01').customDnsConfigs[0].ipAddresses[0] : ''
+var ref_storageAccountPrivateEndpoint = const_configureIHS ? reference(name_storageAccountPrivateEndpoint, '${azure.apiVersionForStorage}').customDnsConfigs[0].ipAddresses[0] : ''
 
 var obj_uamiForDeploymentScript = {
   type: 'UserAssigned'
@@ -612,7 +612,7 @@ resource clusterVMs 'Microsoft.Compute/virtualMachines@${azure.apiVersionForVirt
     diagnosticsProfile: {
       bootDiagnostics: {
         enabled: true
-        storageUri: reference(storageAccount.id, '2023-01-01').primaryEndpoints.blob
+        storageUri: reference(storageAccount.id, '${azure.apiVersionForStorage}').primaryEndpoints.blob
       }
     }
   }
@@ -670,7 +670,7 @@ resource clusterVMsExtension 'Microsoft.Compute/virtualMachines/extensions@${azu
       ]
     }
     protectedSettings: {
-      commandToExecute: format('sh install.sh {0}{1}{2}', i == 0, const_arguments, const_configureIHS ? format(' {0} {1}{2} {3}', name_storageAccount, listKeys(storageAccount.id, '2023-01-01').keys[0].value, const_ihsArguments2, ref_storageAccountPrivateEndpoint) : '')
+      commandToExecute: format('sh install.sh {0}{1}{2}', i == 0, const_arguments, const_configureIHS ? format(' {0} {1}{2} {3}', name_storageAccount, listKeys(storageAccount.id, '${azure.apiVersionForStorage}').keys[0].value, const_ihsArguments2, ref_storageAccountPrivateEndpoint) : '')
     }
   }
   dependsOn: [
@@ -798,7 +798,7 @@ resource ihsVM 'Microsoft.Compute/virtualMachines@${azure.apiVersionForVirtualMa
     diagnosticsProfile: {
       bootDiagnostics: {
         enabled: true
-        storageUri: reference(storageAccount.id, '2023-01-01').primaryEndpoints.blob
+        storageUri: reference(storageAccount.id, '${azure.apiVersionForStorage}').primaryEndpoints.blob
       }
     }
   }
@@ -834,7 +834,7 @@ resource ihsVMExtension 'Microsoft.Compute/virtualMachines/extensions@${azure.ap
       ]
     }
     protectedSettings: {
-      commandToExecute: format('sh configure-ihs.sh{0} {1}{2} {3}', const_ihsArguments1, listKeys(storageAccount.id, '2023-01-01').keys[0].value, const_ihsArguments2, ref_storageAccountPrivateEndpoint)
+      commandToExecute: format('sh configure-ihs.sh{0} {1}{2} {3}', const_ihsArguments1, listKeys(storageAccount.id, '${azure.apiVersionForStorage}').keys[0].value, const_ihsArguments2, ref_storageAccountPrivateEndpoint)
     }
   }
   dependsOn: [

--- a/src/main/bicep/mainTemplate.bicep
+++ b/src/main/bicep/mainTemplate.bicep
@@ -257,7 +257,7 @@ module uamiDeployment 'modules/_uami/_uamiAndRoles.bicep' = if (const_configureA
   }
 }
 
-resource storageAccount 'Microsoft.Storage/storageAccounts@2023-05-01' = {
+resource storageAccount 'Microsoft.Storage/storageAccounts@${azure.apiVersionForStorage}' = {
   name: name_storageAccount
   location: location
   sku: {
@@ -266,7 +266,7 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2023-05-01' = {
   kind: 'StorageV2'
 }
 
-resource storageAccountPrivateEndpoint 'Microsoft.Network/privateEndpoints@2023-11-01' = if (const_configureIHS) {
+resource storageAccountPrivateEndpoint 'Microsoft.Network/privateEndpoints@${azure.apiVersionForPrivateEndpoint}' = if (const_configureIHS) {
   name: name_storageAccountPrivateEndpoint
   location: location
   properties: {
@@ -292,12 +292,12 @@ resource storageAccountPrivateEndpoint 'Microsoft.Network/privateEndpoints@2023-
   ]
 }
 
-resource storageAccountFileSvc 'Microsoft.Storage/storageAccounts/fileServices@2023-05-01' = if (const_configureIHS) {
+resource storageAccountFileSvc 'Microsoft.Storage/storageAccounts/fileServices@${azure.apiVersionForStorageFileService}' = if (const_configureIHS) {
   parent: storageAccount
   name: 'default'
 }
 
-resource storageAccountFileShare 'Microsoft.Storage/storageAccounts/fileServices/shares@2023-05-01' = if (const_configureIHS) {
+resource storageAccountFileShare 'Microsoft.Storage/storageAccounts/fileServices/shares@${azure.apiVersionForStorageFileService}' = if (const_configureIHS) {
   parent: storageAccountFileSvc
   name: name_share
   properties: {
@@ -305,7 +305,7 @@ resource storageAccountFileShare 'Microsoft.Storage/storageAccounts/fileServices
   }
 }
 
-resource networkSecurityGroup 'Microsoft.Network/networkSecurityGroups@2023-11-01' = if (const_newVNet) {
+resource networkSecurityGroup 'Microsoft.Network/networkSecurityGroups@${azure.apiVersionForNetworkSecurityGroups}' = if (const_newVNet) {
   name: name_networkSecurityGroup
   location: location
   properties: {
@@ -367,7 +367,7 @@ resource networkSecurityGroup 'Microsoft.Network/networkSecurityGroups@2023-11-0
   }
 }
 
-resource virtualNetwork 'Microsoft.Network/virtualNetworks@2023-11-01' = if (const_newVNet) {
+resource virtualNetwork 'Microsoft.Network/virtualNetworks@${azure.apiVersionForVirtualNetworks}' = if (const_newVNet) {
   name: vnetForCluster.name
   location: location
   properties: {
@@ -407,22 +407,22 @@ resource virtualNetwork 'Microsoft.Network/virtualNetworks@2023-11-01' = if (con
   }
 }
 
-resource existingVNet 'Microsoft.Network/virtualNetworks@2023-11-01' existing = if (!const_newVNet) {
+resource existingVNet 'Microsoft.Network/virtualNetworks@${azure.apiVersionForVirtualNetworks}' existing = if (!const_newVNet) {
   name: vnetForCluster.name
   scope: resourceGroup(vnetRGNameForCluster)
 }
 
-resource existingAppGwSubnet 'Microsoft.Network/virtualNetworks/subnets@2023-11-01' existing = if (!const_newVNet && const_configureAppGw) {
+resource existingAppGwSubnet 'Microsoft.Network/virtualNetworks/subnets@${azure.apiVersionForVirtualNetworks}' existing = if (!const_newVNet && const_configureAppGw) {
   parent: existingVNet
   name: vnetForCluster.subnets.gatewaySubnet.name
 }
 
-resource existingClusterSubnet 'Microsoft.Network/virtualNetworks/subnets@2023-11-01' existing = if (!const_newVNet) {
+resource existingClusterSubnet 'Microsoft.Network/virtualNetworks/subnets@${azure.apiVersionForVirtualNetworks}' existing = if (!const_newVNet) {
   parent: existingVNet
   name: vnetForCluster.subnets.clusterSubnet.name
 }
 
-resource publicIPAddress 'Microsoft.Network/publicIPAddresses@2023-11-01' = if (const_newVNet) {
+resource publicIPAddress 'Microsoft.Network/publicIPAddresses@${azure.apiVersionForPublicIPAddresses}' = if (const_newVNet) {
   name: name_publicIPAddress
   location: location
   properties: {
@@ -433,7 +433,7 @@ resource publicIPAddress 'Microsoft.Network/publicIPAddresses@2023-11-01' = if (
   }
 }
 
-resource dmgrVMNetworkInterface 'Microsoft.Network/networkInterfaces@2023-11-01' = if (const_newVNet) {
+resource dmgrVMNetworkInterface 'Microsoft.Network/networkInterfaces@${azure.apiVersionForNetworkInterfaces}' = if (const_newVNet) {
   name: '${name_dmgrVM}-if'
   location: location
   properties: {
@@ -460,7 +460,7 @@ resource dmgrVMNetworkInterface 'Microsoft.Network/networkInterfaces@2023-11-01'
   ]
 }
 
-resource dmgrVMNetworkInterfaceNoPubIp 'Microsoft.Network/networkInterfaces@2023-11-01' = if (!const_newVNet) {
+resource dmgrVMNetworkInterfaceNoPubIp 'Microsoft.Network/networkInterfaces@${azure.apiVersionForNetworkInterfaces}' = if (!const_newVNet) {
   name: '${name_dmgrVM}-no-pub-ip-if'
   location: location
   properties: {
@@ -478,7 +478,7 @@ resource dmgrVMNetworkInterfaceNoPubIp 'Microsoft.Network/networkInterfaces@2023
   }
 }
 
-resource managedVMNetworkInterfaces 'Microsoft.Network/networkInterfaces@2023-11-01' = [for i in range(0, (numberOfNodes - 1)): {
+resource managedVMNetworkInterfaces 'Microsoft.Network/networkInterfaces@${azure.apiVersionForNetworkInterfaces}' = [for i in range(0, (numberOfNodes - 1)): {
   name: '${const_managedVMPrefix}${(i + 1)}-if'
   location: location
   properties: {
@@ -573,7 +573,7 @@ module appGatewayEndPid './modules/_pids/_empty.bicep' = if (const_configureAppG
   ]
 }
 
-resource clusterVMs 'Microsoft.Compute/virtualMachines@2024-03-01' = [for i in range(0, numberOfNodes): {
+resource clusterVMs 'Microsoft.Compute/virtualMachines@${azure.apiVersionForVirtualMachines}' = [for i in range(0, numberOfNodes): {
   name: i == 0 ? name_dmgrVM : '${const_managedVMPrefix}${i}'
   location: location
   properties: {
@@ -645,7 +645,8 @@ module dbConnectionStartPid './modules/_pids/_empty.bicep' = if (enableDB) {
   ]
 }
 
-resource clusterVMsExtension 'Microsoft.Compute/virtualMachines/extensions@2024-03-01' = [for i in range(0, numberOfNodes): {
+resource clusterVMsExtension 'Microsoft.Compute/virtualMachines/extensions@${azure.apiVersionForVirtualMachineExtensions}' = [for i in range(0, numberOfNodes): {
+ from azure-common.properties)
   name: format('{0}/install', i == 0 ? name_dmgrVM : '${const_managedVMPrefix}${i}')
   location: location
   properties: {
@@ -701,7 +702,7 @@ module ihsStartPid './modules/_pids/_empty.bicep' = if (const_configureIHS) {
   }
 }
 
-resource ihsPublicIPAddress 'Microsoft.Network/publicIPAddresses@2023-11-01' = if (const_configureIHS && const_newVNet) {
+resource ihsPublicIPAddress 'Microsoft.Network/publicIPAddresses@${azure.apiVersionForPublicIPAddresses}' = if (const_configureIHS && const_newVNet) {
   name: name_ihsPublicIPAddress
   location: location
   properties: {
@@ -712,7 +713,7 @@ resource ihsPublicIPAddress 'Microsoft.Network/publicIPAddresses@2023-11-01' = i
   }
 }
 
-resource ihsVMNetworkInterface 'Microsoft.Network/networkInterfaces@2023-11-01' = if (const_configureIHS && const_newVNet) {
+resource ihsVMNetworkInterface 'Microsoft.Network/networkInterfaces@${azure.apiVersionForNetworkInterfaces}' = if (const_configureIHS && const_newVNet) {
   name: '${name_ihsVM}-if'
   location: location
   properties: {
@@ -739,7 +740,7 @@ resource ihsVMNetworkInterface 'Microsoft.Network/networkInterfaces@2023-11-01' 
   ]
 }
 
-resource ihsVMNetworkInterfaceNoPubIp 'Microsoft.Network/networkInterfaces@2023-11-01' = if (const_configureIHS && !const_newVNet) {
+resource ihsVMNetworkInterfaceNoPubIp 'Microsoft.Network/networkInterfaces@${azure.apiVersionForNetworkInterfaces}' = if (const_configureIHS && !const_newVNet) {
   name: '${name_ihsVM}-no-pub-ip-if'
   location: location
   properties: {
@@ -757,7 +758,8 @@ resource ihsVMNetworkInterfaceNoPubIp 'Microsoft.Network/networkInterfaces@2023-
   }
 }
 
-resource ihsVM 'Microsoft.Compute/virtualMachines@2024-03-01' = if (const_configureIHS) {
+resource ihsVM 'Microsoft.Compute/virtualMachines@${azure.apiVersionForVirtualMachines}' = if (const_configureIHS) {
+ from azure-common.properties)
   name: name_ihsVM
   location: location
   properties: {
@@ -816,7 +818,8 @@ module ihsVMCreated './modules/_pids/_empty.bicep' = if (const_configureIHS) {
   ]
 }
 
-resource ihsVMExtension 'Microsoft.Compute/virtualMachines/extensions@2024-03-01' = if (const_configureIHS) {
+resource ihsVMExtension 'Microsoft.Compute/virtualMachines/extensions@${azure.apiVersionForVirtualMachineExtensions}' = if (const_configureIHS) {
+ from azure-common.properties)
   parent: ihsVM
   name: 'install'
   location: location

--- a/src/main/bicep/mainTemplate.bicep
+++ b/src/main/bicep/mainTemplate.bicep
@@ -210,7 +210,7 @@ var name_publicIPAddress = '${name_dmgrVM}-ip'
 var name_share = 'wasshare'
 var name_storageAccount = 'storage${guidValue}'
 var name_storageAccountPrivateEndpoint = 'storagepe${guidValue}'
-var ref_storageAccountPrivateEndpoint = const_configureIHS ? reference(name_storageAccountPrivateEndpoint, '${azure.apiVersionForStorage}').customDnsConfigs[0].ipAddresses[0] : ''
+var ref_storageAccountPrivateEndpoint = const_configureIHS ? reference(name_storageAccountPrivateEndpoint, '${azure.apiVersionForPrivateEndpoint}').customDnsConfigs[0].ipAddresses[0] : ''
 
 var obj_uamiForDeploymentScript = {
   type: 'UserAssigned'

--- a/src/main/bicep/modules/_appgateway.bicep
+++ b/src/main/bicep/modules/_appgateway.bicep
@@ -33,7 +33,7 @@ param workerNodePrefix string
 var name_appGateway = appGatewayName
 
 // get key vault object from a resource group
-resource existingKeyvault 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
+resource existingKeyvault 'Microsoft.KeyVault/vaults@${azure.apiVersionForKeyVault}' existing = {
   name: keyVaultName
   scope: resourceGroup()
 }

--- a/src/main/bicep/modules/_azure-resources/_appGateway.bicep
+++ b/src/main/bicep/modules/_azure-resources/_appGateway.bicep
@@ -69,7 +69,7 @@ var obj_frontendIPConfigurations1 = [
   }
 ]
 
-resource gatewayPublicIP 'Microsoft.Network/publicIPAddresses@2023-11-01' = {
+resource gatewayPublicIP 'Microsoft.Network/publicIPAddresses@${azure.apiVersionForPublicIPAddresses}' = {
   name: gatewayPublicIPAddressName
   sku: {
     name: 'Standard'
@@ -83,7 +83,7 @@ resource gatewayPublicIP 'Microsoft.Network/publicIPAddresses@2023-11-01' = {
   }
 }
 
-resource wafv2AppGateway 'Microsoft.Network/applicationGateways@2023-11-01' = {
+resource wafv2AppGateway 'Microsoft.Network/applicationGateways3-11-01' = {
   name: name_appGateway
   location: location
   properties: {
@@ -129,7 +129,7 @@ resource wafv2AppGateway 'Microsoft.Network/applicationGateways@2023-11-01' = {
         name: name_managedBackendAddressPool
         properties: {
           backendAddresses: [for i in range(1, numberOfWorkerNodes): {
-            ipAddress: reference(resourceId('Microsoft.Network/networkInterfaces', '${workerNodePrefix}${i}-if'), '2021-08-01').ipConfigurations[0].properties.privateIPAddress
+            ipAddress: reference(resourceId('Microsoft.Network/networkInterfaces', '${workerNodePrefix}${i}-if'), '${azure.apiVersionForNetworkInterfaces}').ipConfigurations[0].properties.privateIPAddress
           }]
         }
       }
@@ -225,7 +225,7 @@ resource wafv2AppGateway 'Microsoft.Network/applicationGateways@2023-11-01' = {
             conditions: [
               {
                 variable: 'http_resp_Location'
-                pattern: format('(https?):\\/\\/{0}:{1}(.*)$', reference(resourceId('Microsoft.Network/networkInterfaces', '${workerNodePrefix}${i}-if'), '2021-08-01').ipConfigurations[0].properties.privateIPAddress, const_backendPort)
+                pattern: format('(https?):\\/\\/{0}:{1}(.*)$', reference(resourceId('Microsoft.Network/networkInterfaces', '${workerNodePrefix}${i}-if'), '${azure.apiVersionForNetworkInterfaces}').ipConfigurations[0].properties.privateIPAddress, const_backendPort)
                 ignoreCase: true
                 negate: false
               }
@@ -250,7 +250,7 @@ resource wafv2AppGateway 'Microsoft.Network/applicationGateways@2023-11-01' = {
             conditions: [
               {
                 variable: 'http_resp_Location'
-                pattern: format('(https?):\\/\\/{0}:{1}(.*)$', reference(resourceId('Microsoft.Network/networkInterfaces', '${workerNodePrefix}${i}-if'), '2021-08-01').ipConfigurations[0].properties.privateIPAddress, const_backendPort)
+                pattern: format('(https?):\\/\\/{0}:{1}(.*)$', reference(resourceId('Microsoft.Network/networkInterfaces', '${workerNodePrefix}${i}-if'), '${azure.apiVersionForNetworkInterfaces}').ipConfigurations[0].properties.privateIPAddress, const_backendPort)
                 ignoreCase: true
                 negate: false
               }

--- a/src/main/bicep/modules/_azure-resources/_appGateway.bicep
+++ b/src/main/bicep/modules/_azure-resources/_appGateway.bicep
@@ -83,7 +83,7 @@ resource gatewayPublicIP 'Microsoft.Network/publicIPAddresses@${azure.apiVersion
   }
 }
 
-resource wafv2AppGateway 'Microsoft.Network/applicationGateways@${azure.apiVersionForApplicationGateways}$' = {
+resource wafv2AppGateway 'Microsoft.Network/applicationGateways@${azure.apiVersionForApplicationGateways}' = {
   name: name_appGateway
   location: location
   properties: {

--- a/src/main/bicep/modules/_azure-resources/_appGateway.bicep
+++ b/src/main/bicep/modules/_azure-resources/_appGateway.bicep
@@ -83,7 +83,7 @@ resource gatewayPublicIP 'Microsoft.Network/publicIPAddresses@${azure.apiVersion
   }
 }
 
-resource wafv2AppGateway 'Microsoft.Network/applicationGateways3-11-01' = {
+resource wafv2AppGateway 'Microsoft.Network/applicationGateways@${azure.apiVersionForApplicationGateways}$' = {
   name: name_appGateway
   location: location
   properties: {

--- a/src/main/bicep/modules/_azure-resources/_keyvault/_keyvaultWithNewCert.bicep
+++ b/src/main/bicep/modules/_azure-resources/_keyvault/_keyvaultWithNewCert.bicep
@@ -45,7 +45,7 @@ param utcValue string = utcNow()
 
 var const_identityId = substring(string(identity.userAssignedIdentities), indexOf(string(identity.userAssignedIdentities), '"') + 1, lastIndexOf(string(identity.userAssignedIdentities), '"') - (indexOf(string(identity.userAssignedIdentities), '"') + 1))
 
-resource keyvault 'Microsoft.KeyVault/vaults@2023-07-01' = {
+resource keyvault 'Microsoft.KeyVault/vaults@${azure.apiVersionForKeyVault}' = {
   name: keyVaultName
   location: location
   properties: {
@@ -57,7 +57,7 @@ resource keyvault 'Microsoft.KeyVault/vaults@2023-07-01' = {
     accessPolicies: [
       {
         // Must specify API version of identity.
-        objectId: reference(const_identityId, '2023-01-31').principalId
+        objectId: reference(const_identityId, '${azure.apiVersionForIdentity}').principalId
         tenantId: subscription().tenantId
         permissions: permission
       }
@@ -72,7 +72,7 @@ resource keyvault 'Microsoft.KeyVault/vaults@2023-07-01' = {
   }
 }
 
-resource createAddCertificate 'Microsoft.Resources/deploymentScripts@2023-08-01' = {
+resource createAddCertificate 'Microsoft.Resources/deploymentScripts@${azure.apiVersionForDeploymentScript}' = {
   name: 'ds-create-add-appgw-certificate'
   location: location
   identity: identity

--- a/src/main/bicep/modules/_deployment-scripts/_dsPostDeployment.bicep
+++ b/src/main/bicep/modules/_deployment-scripts/_dsPostDeployment.bicep
@@ -30,7 +30,7 @@ param utcValue string = utcNow()
 
 var const_scriptLocation = uri(_artifactsLocation, 'scripts/')
 
-resource deploymentScript 'Microsoft.Resources/deploymentScripts@2023-08-01' = {
+resource deploymentScript 'Microsoft.Resources/deploymentScripts@${azure.apiVersionForDeploymentScript}' = {
   name: name
   location: location
   kind: 'AzureCLI'

--- a/src/main/bicep/modules/_uami/_roleAssignment.bicep
+++ b/src/main/bicep/modules/_uami/_roleAssignment.bicep
@@ -37,12 +37,12 @@ param principalId string = ''
 var name_roleAssignmentName = guid('${subscription().id}${principalId}Role assignment in subscription scope')
 
 // Get role resource id in subscription
-resource roleResourceDefinition 'Microsoft.Authorization/roleDefinitions@2022-04-01' existing = {
+resource roleResourceDefinition 'Microsoft.Authorization/roleDefinitions@${azure.apiVersionForRoleDefinitions}' existing = {
   name: roleDefinitionId
 }
 
 // Assign role
-resource roleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+resource roleAssignment 'Microsoft.Authorization/roleAssignments@${azure.apiVersionForRoleAssignment}' = {
   name: name_roleAssignmentName
   properties: {
     description: 'Assign subscription scope role to User Assigned Managed Identity '

--- a/src/main/bicep/modules/_uami/_uamiAndRoles.bicep
+++ b/src/main/bicep/modules/_uami/_uamiAndRoles.bicep
@@ -23,7 +23,7 @@ var name_deploymentScriptUserDefinedManagedIdentity = 'twascluster-vm-deployment
 var name_deploymentScriptContributorRoleAssignmentName = guid('${resourceGroup().id}${name_deploymentScriptUserDefinedManagedIdentity}Deployment Script')
 
 // UAMI for deployment script
-resource uamiForDeploymentScript 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' = {
+resource uamiForDeploymentScript 'Microsoft.ManagedIdentity/userAssignedIdentities@${azure.apiVersionForIdentity}' = {
   name: name_deploymentScriptUserDefinedManagedIdentity
   location: location
 }

--- a/src/main/resources/azure-common.properties
+++ b/src/main/resources/azure-common.properties
@@ -1,0 +1,61 @@
+## Use the following command to get the latest 10 API versions for a given resource type
+## ```bash
+## export NameSpace=<your_name_space>
+## export ResourceType=<your_resource_type>
+## az provider show --namespace ${NameSpace} --query "resourceTypes[?resourceType=='${ResourceType}'].apiVersions[:10]" \
+## | jq -r '.[][] | select(test("preview$"; "i") | not)' | head -n 10
+## ```
+##
+
+# Microsoft.Authorization/roleAssignments
+azure.apiVersionForRoleAssignment=2022-04-01
+# Microsoft.Authorization/roleDefinitions
+azure.apiVersionForRoleDefinitions=2022-04-01
+# Microsoft.ContainerRegistry/registries
+azure.apiVersionForContainerRegistries=2023-07-01
+# Microsoft.ContainerService/managedClusters
+azure.apiVersionForManagedClusters=2023-08-01
+# Microsoft.Compute/availabilitySets
+azure.apiVersionForAvailabilitySets=2023-07-01
+# Microsoft.Compute/virtualMachines
+azure.apiVersionForVirtualMachines=2024-03-01
+# Microsoft.Compute/virtualMachines/extensions
+azure.apiVersionForVirtualMachineExtensions=2024-03-01
+# Microsoft.Compute/virtualMachineScaleSets
+azure.apiVersionForVirtualMachineScaleSets=2024-03-01
+# Microsoft.KeyVault/vaults
+azure.apiVersionForKeyVault=2022-07-01
+# Microsoft.KeyVault/vaults/secrets
+azure.apiVersionForKeyVaultSecrets=2022-07-01
+# Microsoft.ManagedIdentity/userAssignedIdentities
+azure.apiVersionForIdentity=2023-01-31
+# Microsoft.Network/networkInterfaces
+azure.apiVersionForNetworkInterfaces=2023-11-01
+# Microsoft.Network/networkSecurityGroups
+azure.apiVersionForNetworkSecurityGroups=2023-11-01
+# Microsoft.Network/privateEndpoints
+azure.apiVersionForPrivateEndpoint=2023-11-01
+# Microsoft.Network/publicIPAddresses
+azure.apiVersionForPublicIPAddresses=2023-11-01
+# Microsoft.Network/applicationGateways
+azure.apiVersionForApplicationGateways=2023-11-01
+# Microsoft.Network/dnszones
+azure.apiVersionForDNSZone=2023-07-01-preview
+# Microsoft.Network/virtualNetworks
+azure.apiVersionForVirtualNetworks=2023-11-01
+# Microsoft.OperationalInsights/workspaces
+azure.apiVersionForInsightsWorkspaces=2022-10-01
+# Microsoft.Resources/deploymentScripts
+azure.apiVersionForDeploymentScript=2023-08-01
+# Microsoft.Resources/deployments
+azure.apiVersionForDeployment=2022-09-01
+# Microsoft.Resources/tags
+azure.apiVersionForTags=2023-07-01
+# Microsoft.Storage/storageAccounts
+azure.apiVersionForStorage=2023-05-01
+# Microsoft.Storage/storageAccounts/fileServices
+azure.apiVersionForStorageFileService=2023-05-01
+# Microsoft.Storage/storageAccounts/blobServices
+azure.apiVersionForStorageBlobService=2023-05-01
+# Microsoft.RedHatOpenShift/openShiftClusters
+azure.apiVersionForOpenShiftClusters=2023-04-01


### PR DESCRIPTION
## Updates
Refactor: refactor bicep scripts to use version placeholders so all the versions can be managed in the [azure-common.properties](https://github.com/WASdev/azure.websphere-traditional.cluster/blob/5c67c60e244a5c566956594362219804427a0405/src/main/resources/azure-common.properties) file.


## Tests

<img width="1325" alt="image" src="https://github.com/WASdev/azure.websphere-traditional.cluster/assets/4465723/f46727e7-9ee9-4094-9ffc-f4dc5fb77f88">
