### PR TITLE
Fix apiVersions should be recent error

### DIFF
--- a/src/main/resources/azure-common.properties
+++ b/src/main/resources/azure-common.properties
@@ -24,9 +24,9 @@ azure.apiVersionForVirtualMachineExtensions=2024-03-01
 # Microsoft.Compute/virtualMachineScaleSets
 azure.apiVersionForVirtualMachineScaleSets=2024-03-01
 # Microsoft.KeyVault/vaults
-azure.apiVersionForKeyVault=2022-07-01
+azure.apiVersionForKeyVault=2023-07-01
 # Microsoft.KeyVault/vaults/secrets
-azure.apiVersionForKeyVaultSecrets=2022-07-01
+azure.apiVersionForKeyVaultSecrets=2023-07-01
 # Microsoft.ManagedIdentity/userAssignedIdentities
 azure.apiVersionForIdentity=2023-01-31
 # Microsoft.Network/networkInterfaces


### PR DESCRIPTION
Updating `Microsoft.KeyVault/vaults` and `Microsoft.KeyVault/vaults/secrets` to `2023-07-01` to fix  apiVersions should be recent error.

Signed-off-by: Jianguo Ma <jiangma@microsoft.com>