### PR TITLE
Fix tWAS cluster IHS issue

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -346,11 +346,7 @@ jobs:
             websphereCafeUrl=$(echo $outputs | jq -r '.appGatewayHttpURL.value')websphere-cafe
           fi
           if [ -n "$websphereCafeUrl" ]; then
-            curl $websphereCafeUrl
-            if [[ $? -ne 0 ]]; then
-              echo "Failed to access ${websphereCafeUrl}."
-              exit 1
-            fi
+            curl $websphereCafeUrl -k --fail
           fi
       - name: Generate artifact file name and path
         id: artifact_file

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
     <properties>
         <git.repo>WASdev</git.repo>
         <artifactsLocationBase>https://raw.githubusercontent.com/${git.repo}/${project.artifactId}/${git.tag}</artifactsLocationBase>
-        <version.azure.websphere-traditional.cluster>1.3.64</version.azure.websphere-traditional.cluster>
+        <version.azure.websphere-traditional.cluster>1.3.65</version.azure.websphere-traditional.cluster>
     </properties>
 
     <repositories>

--- a/src/main/bicep/modules/_azure-resources/_keyvault/_keyvaultWithNewCert.bicep
+++ b/src/main/bicep/modules/_azure-resources/_keyvault/_keyvaultWithNewCert.bicep
@@ -66,6 +66,7 @@ resource keyvault 'Microsoft.KeyVault/vaults@${azure.apiVersionForKeyVault}' = {
     enabledForDiskEncryption: false
     enabledForTemplateDeployment: true
     enableSoftDelete: true
+    enableRbacAuthorization: false
   }
   tags:{
     'managed-by-azure-twascluster': utcValue

--- a/src/main/scripts/install.sh
+++ b/src/main/scripts/install.sh
@@ -314,7 +314,7 @@ JDBC_DRIVER_CLASS_PATH=
 
 # Create cluster by creating deployment manager, node agent & add nodes to be managed
 if [ "$dmgr" = True ]; then
-    create_dmgr_profile Dmgr001 $(hostname) Dmgr001Node Dmgr001NodeCell "$adminUserName" "$adminPassword"
+    create_dmgr_profile Dmgr001 $(hostname -A) Dmgr001Node Dmgr001NodeCell "$adminUserName" "$adminPassword"
     add_admin_credentials_to_soap_client_props Dmgr001 "$adminUserName" "$adminPassword"
     create_was_service dmgr Dmgr001
     ${WAS_ND_INSTALL_DIRECTORY}/profiles/Dmgr001/bin/startServer.sh dmgr
@@ -341,7 +341,7 @@ if [ "$dmgr" = True ]; then
         fi
     fi
 else
-    create_custom_profile Custom $(hostname) $(hostname)Node01 $dmgrHostName 8879 "$adminUserName" "$adminPassword"
+    create_custom_profile Custom $(hostname -A) $(hostname)Node01 $dmgrHostName.$(hostname -A | cut -d'.' -f2-) 8879 "$adminUserName" "$adminPassword"
     add_admin_credentials_to_soap_client_props Custom "$adminUserName" "$adminPassword"
     create_was_service nodeagent Custom
 


### PR DESCRIPTION
This PR targets to fix #260, which resolves the certificate hostname verification error due to the mismatch between the hostname (short name) included in SAN and the hostname (FQDN) of the cluster member that IHS is trying to route http requests to.

Besides, it also includes a few enhancements which are not related to the mentioned issue:
* fail curl command on http errors
* disable rbac auth explicitly as access policy auth is used in key vault

Pipeline with changes of the PR run successfully: [integration-test](https://github.com/majguo/azure.websphere-traditional.cluster/actions/runs/13299336936)

Signed-off-by: Jianguo Ma <jiangma@microsoft.com>