### PR TITLE
On branch edburns/ibm-1229-get-green-badge-on-upstream

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 * [Liberty on AKS](https://github.com/WASdev/azure.liberty.aks)
 
 # Integration tests report
-[![IT Validation Workflows](https://github.com/azure-javaee/azure.websphere-traditional.cluster/actions/workflows/it-validation-workflows.yaml/badge.svg)](https://github.com/azure-javaee/azure.websphere-traditional.cluster/actions/workflows/it-validation-workflows.yaml)
+[![IT Validation Workflows](https://github.com/WASdev/azure.websphere-traditional.cluster/actions/workflows/it-validation-workflows.yaml/badge.svg)](https://github.com/WASdev/azure.websphere-traditional.cluster/actions/workflows/it-validation-workflows.yaml)
 
 # Deploy RHEL 8.4 VMs on Azure with IBM WebSphere Application Server ND Traditional V9.0.5 cluster and IBM HTTP Server V9.0 pre-installed
 


### PR DESCRIPTION
modified:   README.md

- Reference the correct badge. That is, the upstream badge.